### PR TITLE
Add metadata options to launch template

### DIFF
--- a/modules/launch-templates/main.tf
+++ b/modules/launch-templates/main.tf
@@ -66,6 +66,12 @@ resource "aws_launch_template" "default" {
     enabled = true
   }
 
+  metadata_options {
+    http_endpoint               = var.http_endpoint
+    http_tokens                 = var.http_tokens
+    http_put_response_hop_limit = var.http_put_response_hop_limit
+  }
+
   tag_specifications {
     resource_type = "instance"
     tags          = merge(var.tags, tomap({ "Name" = "${var.cluster_name}-${var.node_group_name}" }))

--- a/modules/launch-templates/variables.tf
+++ b/modules/launch-templates/variables.tf
@@ -51,6 +51,22 @@ variable "post_userdata" {
   description = "Extra snippet to be executed after the main userdata script"
 }
 
+variable "http_endpoint" {
+  type        = string
+  default     = "enabled"
+  description = "Whether the Instance Metadata Service (IMDS) is available. Supported values: enabled, disabled"
+}
+variable "http_tokens" {
+  type        = string
+  default     = "optional"
+  description = "If enabled, will use Instance Metadata Service Version 2 (IMDSv2). Supported values: optional, required."
+}
+variable "http_put_response_hop_limit" {
+  type        = number
+  default     = 1
+  description = "HTTP PUT response hop limit for instance metadata requests. Supported values: 1-64."
+}
+
 variable "node_group_name" {}
 //variable "instance_type" {}
 variable "volume_size" {

--- a/source/main.tf
+++ b/source/main.tf
@@ -532,22 +532,28 @@ module "eks" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "public-launch-templates-on-demand" {
-  source                   = "../modules/launch-templates"
-  cluster_name             = module.eks.cluster_id
-  volume_size              = "50"
-  worker_security_group_id = module.eks.worker_security_group_id
-  node_group_name          = var.on_demand_node_group_name
-  tags                     = module.eks-label.tags
-  public_launch_template   = true
+  source                      = "../modules/launch-templates"
+  cluster_name                = module.eks.cluster_id
+  volume_size                 = "50"
+  worker_security_group_id    = module.eks.worker_security_group_id
+  node_group_name             = var.on_demand_node_group_name
+  tags                        = module.eks-label.tags
+  public_launch_template      = true
+  http_tokens                 = "optional"
+  http_endpoint               = "enabled"
+  http_put_response_hop_limit = 1
 }
 
 module "launch-templates-on-demand" {
-  source                   = "../modules/launch-templates"
-  cluster_name             = module.eks.cluster_id
-  volume_size              = "50"
-  worker_security_group_id = module.eks.worker_security_group_id
-  node_group_name          = var.on_demand_node_group_name
-  tags                     = module.eks-label.tags
+  source                      = "../modules/launch-templates"
+  cluster_name                = module.eks.cluster_id
+  volume_size                 = "50"
+  worker_security_group_id    = module.eks.worker_security_group_id
+  node_group_name             = var.on_demand_node_group_name
+  tags                        = module.eks-label.tags
+  http_tokens                 = "optional"
+  http_endpoint               = "enabled"
+  http_put_response_hop_limit = 1
 }
 
 module "launch-templates-spot" {


### PR DESCRIPTION
*Description of changes:*
Enables the ability to specify metadata options in launch template. Passes default options into source/main.tf as an example and sets variables to have default values. Ability to pass in metadata is useful for tightening security when using IRSA, see https://docs.aws.amazon.com/eks/latest/userguide/best-practices-security.html
