### PR TITLE
Fix hardcoded cluster autoscaler value (#21)

### DIFF
--- a/helm/cluster_autoscaler/README.md
+++ b/helm/cluster_autoscaler/README.md
@@ -68,7 +68,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.2.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.3.0 |
 
 ## Modules
 
@@ -86,6 +86,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_autoscaler_helm_version"></a> [cluster\_autoscaler\_helm\_version](#input\_cluster\_autoscaler\_helm\_version) | n/a | `string` | `"9.9.2"` | no |
 | <a name="input_cluster_autoscaler_image_tag"></a> [cluster\_autoscaler\_image\_tag](#input\_cluster\_autoscaler\_image\_tag) | n/a | `string` | `"v1.20.0"` | no |
+| <a name="input_cluster_autoscaler_region"></a> [cluster\_autoscaler\_region](#input\_cluster\_autoscaler\_region) | The AWS region to target for cluster autoscaling. | `string` | n/a | yes |
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | EKS\_Cluster\_ID | `any` | n/a | yes |
 | <a name="input_image_repo_name"></a> [image\_repo\_name](#input\_image\_repo\_name) | n/a | `string` | `"k8s.gcr.io/autoscaling/cluster-autoscaler"` | no |
 | <a name="input_private_container_repo_url"></a> [private\_container\_repo\_url](#input\_private\_container\_repo\_url) | n/a | `any` | n/a | yes |

--- a/helm/cluster_autoscaler/main.tf
+++ b/helm/cluster_autoscaler/main.tf
@@ -44,7 +44,7 @@ resource "helm_release" "autoscaler" {
   }
   set {
     name  = "awsRegion"
-    value = "eu-west-1"
+    value = var.cluster_autoscaler_region
   }
   set {
     name  = "image.repository"

--- a/helm/cluster_autoscaler/variables.tf
+++ b/helm/cluster_autoscaler/variables.tf
@@ -16,6 +16,10 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+variable "cluster_autoscaler_region" {
+  type        = string
+  description = "The AWS region to target for cluster autoscaling."
+}
 variable "private_container_repo_url" {}
 variable "image_repo_name" {
   default = "k8s.gcr.io/autoscaling/cluster-autoscaler"

--- a/helm/helm.tf
+++ b/helm/helm.tf
@@ -33,6 +33,7 @@ module "cluster_autoscaler" {
   public_docker_repo              = var.public_docker_repo
   cluster_autoscaler_image_tag    = var.cluster_autoscaler_image_tag
   cluster_autoscaler_helm_version = var.cluster_autoscaler_helm_version
+  cluster_autoscaler_region       = var.cluster_autoscaler_region
 }
 
 module "lb_ingress_controller" {

--- a/helm/variables.tf
+++ b/helm/variables.tf
@@ -104,6 +104,7 @@ variable "cluster_autoscaler_image_tag" {}
 
 variable "cluster_autoscaler_helm_version" {}
 
+variable "cluster_autoscaler_region" {}
 
 variable "prometheus_enable" {
   type        = bool

--- a/source/README.md
+++ b/source/README.md
@@ -91,6 +91,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 | <a name="input_cluster_autoscaler_enable"></a> [cluster\_autoscaler\_enable](#input\_cluster\_autoscaler\_enable) | Enabling Cluster autoscaler on eks cluster | `bool` | `false` | no |
 | <a name="input_cluster_autoscaler_helm_version"></a> [cluster\_autoscaler\_helm\_version](#input\_cluster\_autoscaler\_helm\_version) | n/a | `string` | `"9.9.2"` | no |
 | <a name="input_cluster_autoscaler_image_tag"></a> [cluster\_autoscaler\_image\_tag](#input\_cluster\_autoscaler\_image\_tag) | n/a | `string` | `"v1.20.0"` | no |
+| <a name="input_cluster_autoscaler_region"></a> [cluster\_autoscaler\_region](#input\_cluster\_autoscaler\_region) | The AWS region to target for cluster autoscaling. Defaults to the current provider region. | `string` | `""` | no |
 | <a name="input_cluster_log_retention_period"></a> [cluster\_log\_retention\_period](#input\_cluster\_log\_retention\_period) | Number of days to retain cluster logs. Requires `enabled_cluster_log_types` to be set. See https://docs.aws.amazon.com/en_us/eks/latest/userguide/control-plane-logs.html. | `number` | `7` | no |
 | <a name="input_configmap_reload_image_tag"></a> [configmap\_reload\_image\_tag](#input\_configmap\_reload\_image\_tag) | n/a | `string` | `"v0.5.0"` | no |
 | <a name="input_coredns_addon_version"></a> [coredns\_addon\_version](#input\_coredns\_addon\_version) | CoreDNS Addon verison | `string` | `"v1.8.3-eksbuild.1"` | no |

--- a/source/main.tf
+++ b/source/main.tf
@@ -667,6 +667,7 @@ module "helm" {
   cluster_autoscaler_enable       = var.cluster_autoscaler_enable
   cluster_autoscaler_image_tag    = var.cluster_autoscaler_image_tag
   cluster_autoscaler_helm_version = var.cluster_autoscaler_helm_version
+  cluster_autoscaler_region       = var.cluster_autoscaler_region != "" ? var.cluster_autoscaler_region : data.aws_region.current.id
 
   # ------- Metric Server
   metrics_server_enable            = var.metrics_server_enable

--- a/source/variables.tf
+++ b/source/variables.tf
@@ -475,6 +475,12 @@ variable "cluster_autoscaler_helm_version" {
   default = "9.9.2"
 }
 
+variable "cluster_autoscaler_region" {
+  type        = string
+  description = "The AWS region to target for cluster autoscaling. Defaults to the current provider region."
+  default     = ""
+}
+
 variable "prometheus_helm_chart_version" {
   default = "14.4.0"
 }


### PR DESCRIPTION
The goal of this PR is to resolve the hardcoded AWS region issue defined in #21.

*Issue #, if available:* #21

*Description of changes:* 

- Added input variable to allow for customization of the target AWS region for cluster autoscaling.
- Default to the current provider AWS region, if no region is specified.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
