### PR TITLE
Feature/argo application chart

### DIFF
--- a/kubernetes-addons/argocd/argocd-application/Chart.yaml
+++ b/kubernetes-addons/argocd/argocd-application/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: argo-application
+description: A Helm chart that installs an ArgoCD Application resource.
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/kubernetes-addons/argocd/argocd-application/templates/application.yaml
+++ b/kubernetes-addons/argocd/argocd-application/templates/application.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Values.name }}
+  namespace: "argocd"
+spec:
+  project: {{ .Values.project }}
+  source:
+    repoURL: {{ .Values.source.repoUrl }}
+    targetRevision: {{ .Values.source.targetRevision }}
+    path: {{ .Values.source.path }}
+    helm: 
+      values: {{ toYaml .Values.source.helm.values | toString | indent 6 }}
+  destination:
+    server: {{ .Values.destination.server }}
+    namespace: "argocd"
+  syncPolicy:
+    automated: 
+      allowEmpty: false
+      prune: true 
+      selfHeal: true
+    retry: 
+      backoff: 
+        duration: "10s"
+        factor: 2
+        maxDuration: "3m"
+    syncOptions: 
+      - "Validate=false" # disables resource validation (equivalent to 'kubectl apply --validate=false') ( true by default )    
+      - "CreateNamespace=true" # Namespace Auto-Creation ensures that namespace specified as the application destination exists in the destination cluster.
+      - "PrunePropagationPolicy=foreground" # Supported policies are background, foreground and orphan.
+      - "PruneLast=true" # Allow the ability for resource pruning to happen as a final, implicit wave of a sync operation
+      

--- a/kubernetes-addons/argocd/argocd-application/values.yaml
+++ b/kubernetes-addons/argocd/argocd-application/values.yaml
@@ -1,0 +1,25 @@
+# Application Name
+name: ""
+
+# The ArgoCD Project the Application belongs to.
+project: "default"
+
+# Source config for the Application
+source: 
+  
+  # Git Repo the Application points to. 
+  repoUrl: ""
+  
+  # Target revision for the repo. 
+  targetRevision: "HEAD"
+
+  # Path in the repo Argo should look for manifests. 
+  path: ""
+
+  # Helm configuration. 
+  helm :
+    values: ""
+
+# Destination cluster.
+destination:
+  server: "https://kubernetes.default.svc"

--- a/kubernetes-addons/argocd/main.tf
+++ b/kubernetes-addons/argocd/main.tf
@@ -79,57 +79,60 @@ resource "helm_release" "argocd" {
 # ArgoCD App of Apps Bootstrapping
 # ---------------------------------------------------------------------------------------------------------------------
 
-resource "kubernetes_manifest" "argocd_application" {
+resource "helm_release" "argocd_application" {
   for_each = var.argocd_applications
 
-  manifest = {
-    apiVersion : "argoproj.io/v1alpha1"
-    kind : "Application"
-    metadata : {
-      name : each.key
-      namespace : each.value.namespace
-    }
-    spec : {
-      destination : {
-        namespace : each.value.namespace
-        server : each.value.destination
-      }
-      project : each.value.project
-      source : {
-        helm : {
-          releaseName = each.key
-          values : yamlencode(merge(
-            each.value.values,
-            local.global_application_values,
-            each.value.add_on_application ? var.add_on_config : {}
-          ))
-        }
-        path : each.value.path
-        repoURL : each.value.repo_url
-        targetRevision : each.value.target_revision
-      }
-      syncPolicy = {
-        automated = {
-          allowEmpty = false
-          prune      = true
-          selfHeal   = true
-        }
-        retry = {
-          backoff = {
-            duration    = "10s"
-            factor      = 2
-            maxDuration = "3m"
-          }
-          limit = 5
-        }
-        syncOptions = [
-          "Validate=false",                    # disables resource validation (equivalent to 'kubectl apply --validate=false') ( true by default )
-          "CreateNamespace=true",              # Namespace Auto-Creation ensures that namespace specified as the application destination exists in the destination cluster.
-          "PrunePropagationPolicy=foreground", # Supported policies are background, foreground and orphan.
-          "PruneLast=true",                    # Allow the ability for resource pruning to happen as a final, implicit wave of a sync operation
-        ]
-      }
-    }
+  name      = each.key
+  chart     = "${path.module}/argocd-application"
+  version   = "0.1.0"
+  namespace = "argocd"
+
+  # Application Meta. 
+  set {
+    name  = "name"
+    value = each.key
   }
-  depends_on = [helm_release.argocd]
+
+  set {
+    name  = "project"
+    value = each.value.project
+  }
+
+  # Source Config.
+  set {
+    name  = "source.repoUrl"
+    value = each.value.repo_url
+  }
+
+  set {
+    name  = "source.targetRevision"
+    value = each.value.target_revision
+  }
+
+  set {
+    name  = "source.path"
+    value = each.value.path
+  }
+
+  set {
+    name  = "source.helm.releaseName"
+    value = each.key
+  }
+
+  set {
+    name = "source.helm.values"
+    value = yamlencode(merge(
+      each.value.values,
+      local.global_application_values,
+      each.value.add_on_application ? var.add_on_config : {}
+    ))
+  }
+
+  # Desintation Config.
+  set {
+    name  = "destination.server"
+    value = each.value.destination
+  }
+
+  depends_on = [resource.helm_release.argocd]
 }

--- a/kubernetes-addons/windows-vpc-controllers/locals.tf
+++ b/kubernetes-addons/windows-vpc-controllers/locals.tf
@@ -10,6 +10,7 @@ locals {
     namespace                  = "kube-system"
     timeout                    = "600"
     create_namespace           = false
+    set                        = []
     set_sensitive              = null
     lint                       = false
     values                     = local.default_helm_values

--- a/versions.tf
+++ b/versions.tf
@@ -20,15 +20,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.66.0"
+      version = ">= 3.60.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.6.1"
+      version = ">= 2.5.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.4.1"
+      version = ">= 2.3.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/versions.tf
+++ b/versions.tf
@@ -20,15 +20,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.60.0"
+      version = ">= 3.66.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.5.0"
+      version = ">= 2.6.1"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.3.0"
+      version = ">= 2.4.1"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds configuration to apply ArgoCD Applications via a Helm chart. 

Previously, we were relying on the [kubernetes_manifest](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) resource to apply  Argo Applications. This resources requires Kubernetes API access at plan time, meaning a cluster must exist for plan/apply to succeed...which prevented us from enabling a single apply command cluster bootstrapping experience. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
