### PR TITLE
Feature/argo application chart

### DIFF
--- a/docs/add-ons/index.md
+++ b/docs/add-ons/index.md
@@ -68,12 +68,10 @@ If you would like to use private repositories, you can download Docker images fo
 
 ### GitOps with ArgoCD
 
-In order to manage add-ons via ArgoCD, you will leverage the [`ssp-eks-add-ons`](https://github.com/aws-samples/ssp-eks-add-ons) repository. This repository is configured to follow the App of Apps pattern from ArgoCD and has configuration for managing the same set add-ons that are offered directly via Terraform. 
-
 To indicate that you would like to manage add-ons via ArgoCD, you must do the following: 
 
 1. Enable the ArgoCD add-on by setting `argocd_enable` to `true`.
-2. Specify you would like ArgoCD to be responsible for deploying your add-ons by setting `argocd_manage_add_ons` to `true`. This will prevent individual add-on modules from deploying Helm charts.
+2. Specify you would like ArgoCD to be responsible for deploying your add-ons by setting `argocd_manage_add_ons` to `true`. This will prevent the individual Terraform add-on modules from deploying Helm charts.
 3. Pass Application configuration for your add-ons repository via the `argocd_applications` property. 
 
 Note, that the `add_on_application` flag in your `Application` configuration must be set to `true`.
@@ -84,8 +82,8 @@ argocd_manage_add_ons   = true
 argocd_applications     = {
   infra = {
     namespace             = "argocd"
-    path                  = "chart"
-    repo_url              = "https://github.com/aws-samples/ssp-eks-add-ons"
+    path                  = "<path>"
+    repo_url              = "<repo_url>"
     values                = {}
     add_on_application    = true # Indicates the root add-on application. 
   }
@@ -94,7 +92,7 @@ argocd_applications     = {
 
 #### GitOps Bridge 
 
-When managing add-ons via ArgoCD, certain AWS resources may still need to be created via Terraform in order to support add-on functionality (e.g. IAM Roles and Services Account). Certain values will also need to passed from Terraform to ArgoCD via the ArgoCD Application resource's values map. We refer to the mechanism that passes values from Terraform to ArgoCD as the `GitOps Bridge`
+When managing add-ons via ArgoCD, certain AWS resources may still need to be created via Terraform in order to support add-on functionality (e.g. IAM Roles and Services Account). Certain resource values will also need to passed from Terraform to ArgoCD via the ArgoCD Application resource's values map. We refer to this concept as the `GitOps Bridge`
 
 To ensure that AWS resources needed for add-on functionality are created, you still need to indicate in Terraform configuration which add-ons will be managed via ArgoCD. To do so, simply enable the add-ons via their boolean properties. 
 
@@ -104,5 +102,5 @@ cluster_autoscaler_enable   = true # Deploys Cluster Autoscaler Addon
 prometheus_enable           = true # Deploys Prometheus Addon
 ```
 
-This will indicate to each add-on module that it should that it should create the necessary AWS resources and pass the relevant values to the ArgoCD Application resource via the Application's values map. 
+This will indicate to each add-on module that it should create the necessary AWS resources and pass the relevant values to the ArgoCD Application resource via the Application's values map. 
 

--- a/docs/add-ons/index.md
+++ b/docs/add-ons/index.md
@@ -1,55 +1,108 @@
 # Kubernetes Addons Module
 
-The `kubernetes-addons` module within this framework allows you to deploy Kubernetes add-ons using both the Terraform Helm and Kubernetes providers with simple **true/false** flags.
+The [`kubernetes-addons`](../../kubernetes-addons) module within this framework allows you to configure the add-ons you would like deployed into you EKS cluster with simple **true/false** flags.
 
-The framework currently provides support for the following add-ons.
+The framework currently provides support for the following add-ons:
 
 | Add-on    | Description   |
 |-----------|-----------------
 | [Agones](./agones) | Deploys Agones into an EKS cluster. |
+| [ArgoCD](./argocd) | Deploys ArgoCD into an EKS cluster. |
 | [AWS for Fluent Bit](./aws-for-fluent-bit) | Deploys Fluent Bit into an EKS cluster. |
 | [AWS Load Balancer Controller](./fargate-fluent-bit) | Deploys the AWS Load Balancer Controller into an EKS cluster. |
 | [AWS Distro for Open Telemetry](./aws-open-telemetry) | Deploys the AWS Open Telemetry Collector into an EKS cluster. |
 | [cert-manager](./cert-manager) | Deploys cert-manager into an EKS cluster. |
 | [Cluster Autoscaler](./cluster-autoscaler) | Deploys the standard cluster autoscaler into an EKS cluster. |
-| [Fluent Bit for Fargate](./fargate-fluent-but) | Adds Fluent Bit support for EKS Fargate |
+| [Fargate Fluent Bit](./fargate-fluent-bit) | Adds Fluent Bit support for EKS Fargate |
 | [EKS Managed Add-ons](./managed-add-ons) | Enables EKS managed add-ons. |
+| [Keda](./keda) | Deploys Keda into an EKS cluster. |
 | [Metrics Server](./metrics-server) | Deploys the Kubernetes Metrics Server into an EKS cluster. |
 | [Nginx](./nginx) | Deploys the NGINX Ingress Controller into an EKS cluster. |
 | [Prometheus](./prometheus) | Deploys Prometheus into an EKS cluster. |
 | [Traefik](./traefik) | Deploys Traefik Proxy into an EKS cluster.
 | [Windows VPC Controller](./windows-vpc-controllers) |
 
-## Usage
+## Add-on Management
 
-In order to deploy add-ons with the default configuration, simply enable the add-ons via Terraform properties.
+The framework provides two approaches to managing add-on configuration for your EKS clusters. They are:
+
+1. Via Terraform by leveraging the [Terraform Helm provider](https://registry.terraform.io/providers/hashicorp/helm/latest/docs).
+2. Via GitOps with [ArgoCD](https://argo-cd.readthedocs.io/en/stable/).
+
+### Terraform 
+
+The default method for managing add-on configuration is via Terraform. By default, each individual add-on module will do the following:
+
+1. Create any AWS resources needed to support add-on functionality.
+2. Deploy a Helm chart into your EKS cluster by leveraging the Terraform Helm provider. 
+
+In order to deploy an add-on with default configuration, simply enable the add-on via Terraform properties. 
 
 ```hcl
-metrics_server_enable = true            # Deploys Metrics Server Addon
-
-cluster_autoscaler_enable = true        # Deploys Cluster Autoscaler Addon
-
-prometheus_enable = true                # Deploys Prometheus Addon
+metrics_server_enable       = true # Deploys Metrics Server Addon
+cluster_autoscaler_enable   = true # Deploys Cluster Autoscaler Addon
+prometheus_enable           = true # Deploys Prometheus Addon
 ```
 
-The following demonstrates how you can supply optional Helm configuration, including a dedicated values.yaml file.
+To customize the behavior of the Helm charts that are ultimately deployed, you can supply custom Helm configuration. The following demonstrates how you can supply this configuration, including a dedicated `values.yaml` file. 
 
 ```hcl
 metrics_server_helm_chart = {
-    name           = "metrics-server"
-    repository     = "https://kubernetes-sigs.github.io/metrics-server/"
-    chart          = "metrics-server"
-    version        = "3.5.0"
-    namespace      = "kube-system"
-    timeout        = "1200"
+	name           = "metrics-server"
+	repository     = "https://kubernetes-sigs.github.io/metrics-server/"
+	chart          = "metrics-server"
+	version        = "3.5.0"
+	namespace      = "kube-system"
+	timeout        = "1200"
 
-    # (Optional) Example to pass metrics-server-prometheus-values.yaml from your local repo
-    values = [templatefile("${path.module}/k8s_addons/metrics-server-values.yaml", {
-        operating_system                = "linux"
-    })]
+	# (Optional) Example to pass metrics-server-values.yaml from your local repo
+	values = [templatefile("${path.module}/k8s_addons/metrics-server-values.yaml", {
+			operating_system = "linux"
+	})]
 }
 ```
 
-By default, the module is configured to fetch Helm Charts from Open Source repositories and Docker images from Docker Hub/Public ECR repositories. This requires outbound Internet connection from your EKS Cluster.
+Each add-on module is configured to fetch Helm Charts from Open Source, public Helm repositories and Docker images from Docker Hub/Public ECR repositories. This requires outbound Internet connection from your EKS Cluster.
 
-Alternatively you can download the Docker images for each add-on and push them to an AWS ECR repo and this can be accessed within an existing VPC using an ECR endpoint. For instructions on how to do so download existing images, and push them to ECR, see [ECR instructions](../advanced/ecr-instructions.md). Each individual add-on directory contains a README.md file with info on the Helm repositories each add-on uses.
+If you would like to use private repositories, you can download Docker images for each add-on and push them to an AWS ECR repository. ECR can be accessed from within a private existing VPC using an ECR VPC endpoint. For instructions on how to download existing images and push them to ECR, see [ECR instructions](../advanced/ecr-instructions.md). 
+
+### GitOps with ArgoCD
+
+In order to manage add-ons via ArgoCD, you will leverage the [`ssp-eks-add-ons`](https://github.com/aws-samples/ssp-eks-add-ons) repository. This repository is configured to follow the App of Apps pattern from ArgoCD and has configuration for managing the same set add-ons that are offered directly via Terraform. 
+
+To indicate that you would like to manage add-ons via ArgoCD, you must do the following: 
+
+1. Enable the ArgoCD add-on by setting `argocd_enable` to `true`.
+2. Specify you would like ArgoCD to be responsible for deploying your add-ons by setting `argocd_manage_add_ons` to `true`. This will prevent individual add-on modules from deploying Helm charts.
+3. Pass Application configuration for your add-ons repository via the `argocd_applications` property. 
+
+Note, that the `add_on_application` flag in your `Application` configuration must be set to `true`.
+
+```
+argocd_enable           = true
+argocd_manage_add_ons   = true
+argocd_applications     = {
+  infra = {
+    namespace             = "argocd"
+    path                  = "chart"
+    repo_url              = "https://github.com/aws-samples/ssp-eks-add-ons"
+    values                = {}
+    add_on_application    = true # Indicates the root add-on application. 
+  }
+}
+```
+
+#### GitOps Bridge 
+
+When managing add-ons via ArgoCD, certain AWS resources may still need to be created via Terraform in order to support add-on functionality (e.g. IAM Roles and Services Account). Certain values will also need to passed from Terraform to ArgoCD via the ArgoCD Application resource's values map. We refer to the mechanism that passes values from Terraform to ArgoCD as the `GitOps Bridge`
+
+To ensure that AWS resources needed for add-on functionality are created, you still need to indicate in Terraform configuration which add-ons will be managed via ArgoCD. To do so, simply enable the add-ons via their boolean properties. 
+
+```
+metrics_server_enable       = true # Deploys Metrics Server Addon
+cluster_autoscaler_enable   = true # Deploys Cluster Autoscaler Addon
+prometheus_enable           = true # Deploys Prometheus Addon
+```
+
+This will indicate to each add-on module that it should that it should create the necessary AWS resources and pass the relevant values to the ArgoCD Application resource via the Application's values map. 
+

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -4,9 +4,9 @@ This document provides a high level overview of the Core Concepts that are embed
 
 | Concept       | Description                                                           |
 |---------------|-----------------------------------------------------------------------|
-| [Cluster](#cluster) | A Well-Architected EKS Cluster. |
-| [Add-on](#add-on) |  Allow you to configure, deploy, and update the operational software, or add-ons, that provide key functionality to support your Kubernetes applications. |
-| [Team](#team) | A logical grouping of IAM identities that have access to a Kubernetes namespace(s). |
+| [Cluster](#cluster) | An Amazon EKS Cluster and associated worker groups. |
+| [Add-on](#add-on) | Operational software that provides key functionality to support your Kubernetes applications. |
+| [Team](#team) | A logical grouping of IAM identities that have access to Kubernetes resources. |
 | [Pipeline](#pipeline) | Continuous Delivery pipelines for deploying `clusters` and `add-ons`. |
 | [Application](#application) | An application that runs within an EKS Cluster. |
 
@@ -20,9 +20,9 @@ See our [Node Groups](./node-groups) documentation page for detailed information
 
 `Add-ons` allow you to configure the operational tools that you would like to deploy into your EKS cluster. When you configure `add-ons` for a `cluster`, the `add-ons` will be provisioned at deploy time by leveraging the Terraform Helm provider. Add-ons can deploy both Kubernetes specific resources and AWS resources needed to support add-on functionality.
 
-For examples, the `metrics-server` add-on only deploys the Kubernetes manifests that are needed to run the Kubernetes Metrics Server. By contrast, the `aws-load-balancer-controller` add-on deploys both Kubernetes YAML, in addition to creating resources via AWS APIs that are needed to support the AWS Load Balancer Controller functionality.
+For example, the `metrics-server` add-on only deploys the Kubernetes manifests that are needed to run the Kubernetes Metrics Server. By contrast, the `aws-load-balancer-controller` add-on deploys both Kubernetes YAML, in addition to creating resources via AWS APIs that are needed to support the AWS Load Balancer Controller functionality.
 
-See our [`Add-ons`](./add-ons) documentation page for detailed information.
+The `terraform-ssp-amazon-eks` framework allows you to manage your add-ons directly via Terraform (by leveraging the Terraform Helm provider) or via GitOps with ArgoCD. See our [`Add-ons`](./add-ons) documentation page for detailed information.
 
 ## Team
 

--- a/kubernetes-addons/argocd/argocd-application/Chart.yaml
+++ b/kubernetes-addons/argocd/argocd-application/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: argo-application
+description: A Helm chart that installs an ArgoCD Application resource.
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/kubernetes-addons/argocd/argocd-application/templates/application.yaml
+++ b/kubernetes-addons/argocd/argocd-application/templates/application.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Values.name }}
+  namespace: "argocd"
+spec:
+  project: {{ .Values.project }}
+  source:
+    repoURL: {{ .Values.source.repoUrl }}
+    targetRevision: {{ .Values.source.targetRevision }}
+    path: {{ .Values.source.path }}
+    helm: 
+      values: {{ toYaml .Values.source.helm.values | toString | indent 6 }}
+  destination:
+    server: {{ .Values.destination.server }}
+    namespace: "argocd"
+  syncPolicy:
+    automated: 
+      allowEmpty: false
+      prune: true 
+      selfHeal: true
+    retry: 
+      backoff: 
+        duration: "10s"
+        factor: 2
+        maxDuration: "3m"
+    syncOptions: 
+      - "Validate=false" # disables resource validation (equivalent to 'kubectl apply --validate=false') ( true by default )    
+      - "CreateNamespace=true" # Namespace Auto-Creation ensures that namespace specified as the application destination exists in the destination cluster.
+      - "PrunePropagationPolicy=foreground" # Supported policies are background, foreground and orphan.
+      - "PruneLast=true" # Allow the ability for resource pruning to happen as a final, implicit wave of a sync operation
+      

--- a/kubernetes-addons/argocd/argocd-application/values.yaml
+++ b/kubernetes-addons/argocd/argocd-application/values.yaml
@@ -1,0 +1,25 @@
+# Application Name
+name: ""
+
+# The ArgoCD Project the Application belongs to.
+project: "default"
+
+# Source config for the Application
+source: 
+  
+  # Git Repo the Application points to. 
+  repoUrl: ""
+  
+  # Target revision for the repo. 
+  targetRevision: "HEAD"
+
+  # Path in the repo Argo should look for manifests. 
+  path: ""
+
+  # Helm configuration. 
+  helm :
+    values: ""
+
+# Destination cluster.
+destination:
+  server: "https://kubernetes.default.svc"

--- a/kubernetes-addons/argocd/main.tf
+++ b/kubernetes-addons/argocd/main.tf
@@ -79,57 +79,60 @@ resource "helm_release" "argocd" {
 # ArgoCD App of Apps Bootstrapping
 # ---------------------------------------------------------------------------------------------------------------------
 
-resource "kubernetes_manifest" "argocd_application" {
+resource "helm_release" "argocd_application" {
   for_each = var.argocd_applications
 
-  manifest = {
-    apiVersion : "argoproj.io/v1alpha1"
-    kind : "Application"
-    metadata : {
-      name : each.key
-      namespace : each.value.namespace
-    }
-    spec : {
-      destination : {
-        namespace : each.value.namespace
-        server : each.value.destination
-      }
-      project : each.value.project
-      source : {
-        helm : {
-          releaseName = each.key
-          values : yamlencode(merge(
-            each.value.values,
-            local.global_application_values,
-            each.value.add_on_application ? var.add_on_config : {}
-          ))
-        }
-        path : each.value.path
-        repoURL : each.value.repo_url
-        targetRevision : each.value.target_revision
-      }
-      syncPolicy = {
-        automated = {
-          allowEmpty = false
-          prune      = true
-          selfHeal   = true
-        }
-        retry = {
-          backoff = {
-            duration    = "10s"
-            factor      = 2
-            maxDuration = "3m"
-          }
-          limit = 5
-        }
-        syncOptions = [
-          "Validate=false",                    # disables resource validation (equivalent to 'kubectl apply --validate=false') ( true by default )
-          "CreateNamespace=true",              # Namespace Auto-Creation ensures that namespace specified as the application destination exists in the destination cluster.
-          "PrunePropagationPolicy=foreground", # Supported policies are background, foreground and orphan.
-          "PruneLast=true",                    # Allow the ability for resource pruning to happen as a final, implicit wave of a sync operation
-        ]
-      }
-    }
+  name      = each.key
+  chart     = "${path.module}/argocd-application"
+  version   = "0.1.0"
+  namespace = "argocd"
+
+  # Application Meta. 
+  set {
+    name  = "name"
+    value = each.key
   }
-  depends_on = [helm_release.argocd]
+
+  set {
+    name  = "project"
+    value = each.value.project
+  }
+
+  # Source Config.
+  set {
+    name  = "source.repoUrl"
+    value = each.value.repo_url
+  }
+
+  set {
+    name  = "source.targetRevision"
+    value = each.value.target_revision
+  }
+
+  set {
+    name  = "source.path"
+    value = each.value.path
+  }
+
+  set {
+    name  = "source.helm.releaseName"
+    value = each.key
+  }
+
+  set {
+    name = "source.helm.values"
+    value = yamlencode(merge(
+      each.value.values,
+      local.global_application_values,
+      each.value.add_on_application ? var.add_on_config : {}
+    ))
+  }
+
+  # Desintation Config.
+  set {
+    name  = "destination.server"
+    value = each.value.destination
+  }
+
+  depends_on = [resource.helm_release.argocd]
 }

--- a/kubernetes-addons/windows-vpc-controllers/locals.tf
+++ b/kubernetes-addons/windows-vpc-controllers/locals.tf
@@ -10,6 +10,7 @@ locals {
     namespace                  = "kube-system"
     timeout                    = "600"
     create_namespace           = false
+    set                        = []
     set_sensitive              = null
     lint                       = false
     values                     = local.default_helm_values

--- a/locals.tf
+++ b/locals.tf
@@ -95,7 +95,6 @@ locals {
     ingressNginx              = var.nginx_ingress_controller_enable ? module.nginx_ingress[0].argocd_gitops_config : {}
     keda                      = var.keda_enable ? module.keda[0].argocd_gitops_config : {}
     metricsServer             = var.metrics_server_enable ? module.metrics_server[0].argocd_gitops_config : {}
-    nginxIngress              = var.nginx_ingress_controller_enable ? module.nginx_ingress[0].argocd_gitops_config : {}
     prometheus                = var.prometheus_enable ? module.prometheus[0].argocd_gitops_config : {}
     sparkOperator             = var.spark_on_k8s_operator_enable ? module.spark-k8s-operator[0].argocd_gitops_config : {}
     traefik                   = var.traefik_ingress_controller_enable ? module.traefik_ingress[0].argocd_gitops_config : {}

--- a/locals.tf
+++ b/locals.tf
@@ -85,20 +85,20 @@ locals {
   service_account_amp_query_name  = format("%s-%s", module.aws_eks.cluster_id, "amp-query")
 
   # Configuration for managing add-ons via ArgoCD.
-  argocd_add_on_config = {
-    agones                    = var.agones_enable ? module.agones[0].argocd_gitops_config : null
-    awsForFluentBit           = var.aws_for_fluentbit_enable ? module.aws_for_fluent_bit[0].argocd_gitops_config : null
-    awsLoadBalancerController = var.aws_lb_ingress_controller_enable ? module.aws_load_balancer_controller[0].argocd_gitops_config : null
-    awsOtelCollector          = var.aws_open_telemetry_enable ? module.aws_opentelemetry_collector[0].argocd_gitops_config : null
-    certManager               = var.cert_manager_enable ? module.cert_manager[0].argocd_gitops_config : null
-    clusterAutoscaler         = var.cluster_autoscaler_enable ? module.cluster_autoscaler[0].argocd_gitops_config : null
-    ingressNginx              = var.nginx_ingress_controller_enable ? module.nginx_ingress[0].argocd_gitops_config : null
-    keda                      = var.keda_enable ? module.keda[0].argocd_gitops_config : null
-    metricsServer             = var.metrics_server_enable ? module.metrics_server[0].argocd_gitops_config : null
-    nginxIngress              = var.nginx_ingress_controller_enable ? module.nginx_ingress[0].argocd_gitops_config : null
-    prometheus                = var.prometheus_enable ? module.prometheus[0].argocd_gitops_config : null
-    sparkOperator             = var.spark_on_k8s_operator_enable ? module.spark-k8s-operator[0].argocd_gitops_config : null
-    traefik                   = var.traefik_ingress_controller_enable ? module.traefik_ingress[0].argocd_gitops_config : null
-    windowsVpcControllers     = var.enable_windows_support ? module.windows_vpc_controllers[0].argocd_gitops_config : null
-  }
+  argocd_add_on_config = var.argocd_manage_add_ons ? {
+    agones                    = var.agones_enable ? module.agones[0].argocd_gitops_config : {}
+    awsForFluentBit           = var.aws_for_fluentbit_enable ? module.aws_for_fluent_bit[0].argocd_gitops_config : {}
+    awsLoadBalancerController = var.aws_lb_ingress_controller_enable ? module.aws_load_balancer_controller[0].argocd_gitops_config : {}
+    awsOtelCollector          = var.aws_open_telemetry_enable ? module.aws_opentelemetry_collector[0].argocd_gitops_config : {}
+    certManager               = var.cert_manager_enable ? module.cert_manager[0].argocd_gitops_config : {}
+    clusterAutoscaler         = var.cluster_autoscaler_enable ? module.cluster_autoscaler[0].argocd_gitops_config : {}
+    ingressNginx              = var.nginx_ingress_controller_enable ? module.nginx_ingress[0].argocd_gitops_config : {}
+    keda                      = var.keda_enable ? module.keda[0].argocd_gitops_config : {}
+    metricsServer             = var.metrics_server_enable ? module.metrics_server[0].argocd_gitops_config : {}
+    nginxIngress              = var.nginx_ingress_controller_enable ? module.nginx_ingress[0].argocd_gitops_config : {}
+    prometheus                = var.prometheus_enable ? module.prometheus[0].argocd_gitops_config : {}
+    sparkOperator             = var.spark_on_k8s_operator_enable ? module.spark-k8s-operator[0].argocd_gitops_config : {}
+    traefik                   = var.traefik_ingress_controller_enable ? module.traefik_ingress[0].argocd_gitops_config : {}
+    windowsVpcControllers     = var.enable_windows_support ? module.windows_vpc_controllers[0].argocd_gitops_config : {}
+  } : {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -379,6 +379,13 @@ variable "argocd_applications" {
   default     = {}
   description = "ARGO CD Applications config to bootstrap the cluster"
 }
+
+variable "argocd_manage_add_ons" {
+  type        = bool
+  default     = false
+  description = "Enables managing add-on configuration via ArgoCD"
+}
+
 #-----------AWS NODE TERMINATION HANDLER-------------
 variable "aws_node_termination_handler_enable" {
   type        = bool
@@ -390,11 +397,7 @@ variable "aws_node_termination_handler_helm_chart" {
   description = "Helm chart definition for aws_node_termination_handler"
   default     = {}
 }
-variable "argocd_manage_add_ons" {
-  type        = bool
-  default     = false
-  description = "Enables managing add-on configuration via ArgoCD"
-}
+
 #-----------KEDA ADDON-------------
 variable "keda_enable" {
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -20,15 +20,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.66.0"
+      version = ">= 3.60.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.6.1"
+      version = ">= 2.5.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.4.1"
+      version = ">= 2.3.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/versions.tf
+++ b/versions.tf
@@ -20,15 +20,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.60.0"
+      version = ">= 3.66.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.5.0"
+      version = ">= 2.6.1"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.3.0"
+      version = ">= 2.4.1"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This pull requests adds support for deploying ArgoCD Application resources to a cluster via a dedicated Helm chart. 

Previously, we used the [`kubernetes_manifest`](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) resource to create Application resources. The issue with this approach is that the `kubernetes_manifest` resource requires a Kubernetes API to exist at plan/apply time. This breaks our approach to enabling a single command apply which bootstraps an entire EKS environment. Creating Applications via a Helm chart solves this issue. 

The PR also includes expanded add-on documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
