### PR TITLE
Change source URL of the module and add release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ The below demonstrates how you can leverage this framework to deploy an EKS clus
 
 ```hcl
 module "eks-ssp" {
-    source = "git@github.com:aws-samples/aws-eks-accelerator-for-terraform.git"
+    source = "git::https://github.com/aws-samples/aws-eks-accelerator-for-terraform.git?ref=v3.1.1"
+    
 
     # EKS CLUSTER
     kubernetes_version       = "1.21"


### PR DESCRIPTION
Using `source = "git@github.com:aws-samples/aws-eks-accelerator-for-terraform.git"` gives me the following error message: 

```
Error: Failed to download module
│
│ Could not download module "eks-ssp" (k8s.tf:3) source code from "git@github.com:aws-samples/aws-eks-accelerator-for-terraform.git": error downloading
│ 'ssh://git@github.com/aws-samples/aws-eks-accelerator-for-terraform.git': C:\Program Files\Git\cmd\git.exe exited with 128: Cloning into '.terraform\modules\eks-ssp'...
│ Host key verification failed.
│ fatal: Could not read from remote repository.
│
│ Please make sure you have the correct access rights
│ and the repository exists.
```

In addition, I suggest to add the release version in the source URL.

Do you plan to publish this module at the Terraform registry?

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
