### PR TITLE
`Set` default value of helm_release windows_vpc_controllers to null

### DIFF
--- a/kubernetes-addons/windows-vpc-controllers/locals.tf
+++ b/kubernetes-addons/windows-vpc-controllers/locals.tf
@@ -10,6 +10,7 @@ locals {
     namespace                  = "kube-system"
     timeout                    = "600"
     create_namespace           = false
+    set                        = null
     set_sensitive              = null
     lint                       = false
     values                     = local.default_helm_values


### PR DESCRIPTION
I got the following error
```
╷
│ Error: Invalid index
│
│   on .terraform\modules\eks\kubernetes-addons\windows-vpc-controllers\main.tf line 60, in resource "helm_release" "windows_vpc_controllers":
│   60:     for_each = local.windows_vpc_controllers_helm_app["set"] == null ? [] : local.windows_vpc_controllers_helm_app["set"]
│     ├────────────────
│     │ local.windows_vpc_controllers_helm_app is object with 34 attributes
│
│ The given key does not identify an element in this collection value.
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
