### PR TITLE
team manifest optional attribute , cleaner docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![GitHub](https://img.shields.io/github/license/aws-samples/aws-eks-accelerator-for-terraform)
 [![e2e-test](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/actions/workflows/e2e-test.yml/badge.svg)](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/actions/workflows/e2e-test.yml)
 
-**Note**: EKS SSP for Terraform is in active development and should be considered a **pre-production** framework. Backwards incompatible Terraform changes are possible in future releases and support is best-effort by the EKS SSP community.
+> **Note**: EKS SSP for Terraform is in active development and should be considered a **pre-production** framework. Backwards incompatible Terraform changes are possible in future releases and support is best-effort by the EKS SSP community.
 
 Welcome to the Amazon EKS Shared Services Platform (SSP) for Terraform.
 

--- a/modules/aws-eks-teams/README.md
+++ b/modules/aws-eks-teams/README.md
@@ -2,14 +2,17 @@
 
 ## Introduction
 
-The `ssp-amazon-eks` framework provides support for onboarding and managing teams and easily configuring cluster access. We currently support two "`Team`" types: `application_teams` and `platform_teams`.
+The `ssp-amazon-eks` framework provides support for onboarding and managing teams and easily configuring cluster access. We currently support two "`Team`" types: `application_teams` and `platform_teams`.  
 `Application Teams` represent teams managing workloads running in cluster namespaces and `Platform Teams` represents platform administrators who have admin access (masters group) to clusters.
 
 ### ApplicationTeam
 
-To create an `application_team` for your cluster, you will need to supply a team name, with the options to pass map of labels, map of resource quotas, existing IAM entities (user/roles), and a directory where you may optionally place any policy definitions and generic manifests for the team.
-These manifests will be applied by the platform and will be outside of the team control
-**NOTE:** When the manifests are applied, namespaces are not checked. Therefore, you are responsible for namespace settings in the yaml files.
+To create an `application_team` for your cluster, you will need to supply a team name, with the options to pass map of labels, map of resource quotas, existing IAM entities (user/roles), and a directory where you may optionally place any policy definitions and generic manifests for the team.  
+These manifests will be applied by the platform and will be outside of the team control  
+
+**NOTE:** When the manifests are applied, namespaces are not checked. Therefore, you are responsible for namespace settings in the yaml files.  
+> As of today (2020-05-01), resource `kubernetes_manifest` can only be used (`terraform plan/apply...`) only after the cluster has been created and the cluster API can be accessed. Read ["Before you use this resource"](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest#before-you-use-this-resource) section for more information.  
+To overcome this limitation, you can add/enable `manifests_dir` after you applied and created the cluster first. We are working on a better solution for this.
 
 #### Application Team Example
 

--- a/modules/aws-eks-teams/locals.tf
+++ b/modules/aws-eks-teams/locals.tf
@@ -7,7 +7,7 @@ locals {
 
   team_manifests = flatten([
     for team_name, team_data in var.application_teams :
-    fileset(path.root, "${team_data.manifests_dir}/*")
+    try(fileset(path.root, "${team_data.manifests_dir}/*"), [])
   ])
 
   platform_teams_config_map = length(var.platform_teams) > 0 ? [


### PR DESCRIPTION
*Issue #, if available:*
if `manifests_dir` was not mentioned under teams, it would fail with error that the attribute doesn't exists under the object.
manifests is not mandatory given by user.

*Description of changes:*
- use TF `try` functionality, as if the attribute doesn't exists return empty set.
- Added temp docs for current situation while using `kubernetes_manifest` while discussing with the team alternative options, for now, users can achieve using the manifests by 2 step deployment. First, deploy the cluster without enabling `manifests_dir` , then enable and added `manifests_dir` and TF apply again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
