### PR TITLE
kubectl_manifest for teams manifests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v4.0.1
     hooks:
       - id: trailing-whitespace
+        args: ['--markdown-linebreak-ext=md']
       - id: check-yaml
         exclude: '[\w\-\/]+/templates/'
       - id: end-of-file-fixer

--- a/modules/aws-eks-teams/main.tf
+++ b/modules/aws-eks-teams/main.tf
@@ -176,9 +176,12 @@ resource "kubernetes_service_account" "team" {
 # Kubernetes Manifests
 # ---------------------------------------------------------------------------------------------------------------------
 
-resource "kubernetes_manifest" "team" {
-  for_each = { for manifest in local.team_manifests : manifest => manifest }
-  manifest = yamldecode(file(each.key))
+resource "kubectl_manifest" "team" {
+  for_each  = { for manifest in local.team_manifests : manifest => file(manifest) }
+  yaml_body = each.value
+  depends_on = [
+    kubernetes_namespace.team
+  ]
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/aws-eks-teams/versions.tf
+++ b/modules/aws-eks-teams/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.7.0"
+    }
+  }
+}

--- a/providers.tf
+++ b/providers.tf
@@ -38,3 +38,11 @@ provider "helm" {
     cluster_ca_certificate = var.create_eks ? base64decode(data.aws_eks_cluster.cluster.0.certificate_authority.0.data) : ""
   }
 }
+
+
+provider "kubectl" {
+  host                   = var.create_eks ? data.aws_eks_cluster.cluster.0.endpoint : ""
+  cluster_ca_certificate = var.create_eks ? base64decode(data.aws_eks_cluster.cluster.0.certificate_authority.0.data) : ""
+  token                  = var.create_eks ? data.aws_eks_cluster_auth.cluster.0.token : ""
+  load_config_file       = false
+}

--- a/versions.tf
+++ b/versions.tf
@@ -42,6 +42,10 @@ terraform {
       source  = "terraform-aws-modules/http"
       version = "2.4.1"
     }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.7.0"
+    }
   }
   required_version = ">= 1.0.0"
 }


### PR DESCRIPTION
*Issue #, if available:*
Using `kubernetes_manifest` requires the cluster to be up and running and the API endpoint to be accessible, scenario where you first create a cluster with teams will cause the teams manifests to fail first because of it.

*Description of changes:*
- Using `kubectl_manifest` from `kubectl` provider https://registry.terraform.io/providers/gavinbunney/kubectl/latest

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
