### PR TITLE
export locals from emr module, remove enable var

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 | <a name="input_create_eks"></a> [create\_eks](#input\_create\_eks) | Enable Create EKS | `bool` | `false` | no |
 | <a name="input_emr_on_eks_teams"></a> [emr\_on\_eks\_teams](#input\_emr\_on\_eks\_teams) | EMR on EKS Teams configuration | `any` | `{}` | no |
 | <a name="input_enable_coredns_addon"></a> [enable\_coredns\_addon](#input\_enable\_coredns\_addon) | Enable CoreDNS Addon | `bool` | `false` | no |
-| <a name="input_enable_emr_on_eks"></a> [enable\_emr\_on\_eks](#input\_enable\_emr\_on\_eks) | Enabling EMR on EKS Config | `bool` | `false` | no |
 | <a name="input_enable_irsa"></a> [enable\_irsa](#input\_enable\_irsa) | Indicates whether or not the Amazon EKS public API server endpoint is enabled. Default to AWS EKS resource and it is true | `bool` | `true` | no |
 | <a name="input_enable_kube_proxy_addon"></a> [enable\_kube\_proxy\_addon](#input\_enable\_kube\_proxy\_addon) | Enable Kube Proxy Addon | `bool` | `false` | no |
 | <a name="input_enable_vpc_cni_addon"></a> [enable\_vpc\_cni\_addon](#input\_enable\_vpc\_cni\_addon) | Enable VPC CNI Addon | `bool` | `false` | no |

--- a/deploy/advanced/live/preprod/eu-west-1/application_acct/dev/main.tf
+++ b/deploy/advanced/live/preprod/eu-west-1/application_acct/dev/main.tf
@@ -579,7 +579,6 @@ module "aws-eks-accelerator-for-terraform" {
   #---------------------------------------
   # ENABLE EMR ON EKS
   #---------------------------------------
-  enable_emr_on_eks = true
 
   emr_on_eks_teams = {
     data_team_a = {

--- a/docs/modules/emr-on-eks.md
+++ b/docs/modules/emr-on-eks.md
@@ -18,7 +18,6 @@ This module deploys the necessary resources to run EMR Spark Jobs on EKS Cluster
   #---------------------------------------
   # ENABLE EMR ON EKS
   #---------------------------------------
-  enable_emr_on_eks = true
 
   emr_on_eks_teams = {
     data_team_a = {

--- a/locals.tf
+++ b/locals.tf
@@ -73,13 +73,7 @@ locals {
   ] : []
 
   # EMR on EKS IAM Roles for aws-auth
-  emr_on_eks_config_map = var.enable_emr_on_eks == true ? [
-    {
-      rolearn : "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/AWSServiceRoleForAmazonEMRContainers"
-      username : "emr-containers"
-      groups : []
-    }
-  ] : []
+  emr_on_eks_config_map           = module.emr_on_eks.emr_on_eks_config_map
   platform_teams_config_map       = module.aws_eks_teams.platform_teams_config_map
   application_teams_config_map    = module.aws_eks_teams.application_teams_config_map
   service_account_amp_ingest_name = format("%s-%s", module.aws_eks.cluster_id, "amp-ingest")

--- a/main.tf
+++ b/main.tf
@@ -96,7 +96,7 @@ module "emr_on_eks" {
   source = "./modules/emr-on-eks"
 
   for_each = { for key, value in var.emr_on_eks_teams : key => value
-    if var.enable_emr_on_eks && length(var.emr_on_eks_teams) > 0
+    if length(var.emr_on_eks_teams) > 0
   }
 
   emr_on_eks_teams = each.value

--- a/modules/emr-on-eks/locals.tf
+++ b/modules/emr-on-eks/locals.tf
@@ -9,4 +9,12 @@ locals {
     var.emr_on_eks_teams
   )
   emr_service_name = "emr-containers"
+
+  emr_on_eks_config_map = length(var.emr_on_eks_teams) > 0 ? [
+    {
+      rolearn : "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/AWSServiceRoleForAmazonEMRContainers"
+      username : "emr-containers"
+      groups : []
+    }
+  ] : []
 }

--- a/modules/emr-on-eks/outputs.tf
+++ b/modules/emr-on-eks/outputs.tf
@@ -8,3 +8,8 @@ output "emr_on_eks_role_id" {
   description = "IAM execution role ID for EMR on EKS"
   value       = aws_iam_role.emr_on_eks_execution[*].id
 }
+
+output "emr_on_eks_config_map" {
+  description = "EMR on EKS Auth Configmap"
+  value       = local.emr_on_eks_config_map
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -113,12 +113,12 @@ output "fargate_profiles_aws_auth_config_map" {
 
 output "emr_on_eks_role_arn" {
   description = "IAM execution role ARN for EMR on EKS"
-  value       = var.create_eks && var.enable_emr_on_eks ? values({ for nodes in sort(keys(var.emr_on_eks_teams)) : nodes => join(",", module.emr_on_eks[nodes].emr_on_eks_role_arn) }) : []
+  value       = var.create_eks && length(var.emr_on_eks_teams) > 0 ? values({ for nodes in sort(keys(var.emr_on_eks_teams)) : nodes => join(",", module.emr_on_eks[nodes].emr_on_eks_role_arn) }) : []
 }
 
 output "emr_on_eks_role_id" {
   description = "IAM execution role ID for EMR on EKS"
-  value       = var.create_eks && var.enable_emr_on_eks ? values({ for nodes in sort(keys(var.emr_on_eks_teams)) : nodes => join(",", module.emr_on_eks[nodes].emr_on_eks_role_id) }) : []
+  value       = var.create_eks && length(var.emr_on_eks_teams) > 0 ? values({ for nodes in sort(keys(var.emr_on_eks_teams)) : nodes => join(",", module.emr_on_eks[nodes].emr_on_eks_role_id) }) : []
 }
 
 output "teams" {

--- a/variables.tf
+++ b/variables.tf
@@ -211,12 +211,6 @@ variable "aws_auth_additional_labels" {
 
 # KUBERNETES ADDONS VARIABLES
 
-variable "enable_emr_on_eks" {
-  type        = bool
-  default     = false
-  description = "Enabling EMR on EKS Config"
-}
-
 variable "emr_on_eks_teams" {
   description = "EMR on EKS Teams configuration"
   type        = any


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- removing `enable_` var as it's not needed, can check by length of given `emr_on_eks_teams`
- auth config local moved to module, exported via output, root module to use output instead.

Need to submit PR for patterns/example and verify E2E changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
