### PR TITLE
test: fail e2e job if tf apply failed

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -65,3 +65,12 @@ jobs:
           working-directory: test/e2e/eks
           run: terraform destroy -no-color -auto-approve
           continue-on-error: false
+
+        - name: Fail if TF apply failed
+          if: steps.apply.outcome == 'failure'
+          id: fail-if-tf-apply-failed
+          run: |
+            echo "Terraform Apply step failed...Please check the logs of the Terraform Apply step."
+            echo "Failing the job to avoid false positives."
+            exit 1
+          continue-on-error: false


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
new step that will explicitly check the TF apply step outcome, if it was failure it will fail the whole job after TF destroy step, this is to ensure GH workflow will mark jobs as failures, right now it shows jobs that have TF apply has passed because `continue-on-error: true` is applied to the apply step.
This is mainly needed for proper alerting and avoiding false positives.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
