### PR TITLE
disable k8s addons providers, passing provider instead

### DIFF
--- a/deploy/2-eks-cluster-with-import-vpc/eks/main.tf
+++ b/deploy/2-eks-cluster-with-import-vpc/eks/main.tf
@@ -170,6 +170,7 @@ module "kubernetes-addons" {
   providers = {
     kubernetes = kubernetes
     helm       = helm
+    aws        = aws
   }
 
   source = "../../../modules/kubernetes-addons"

--- a/modules/kubernetes-addons/providers.tf
+++ b/modules/kubernetes-addons/providers.tf
@@ -17,24 +17,24 @@
  */
 
 
-provider "aws" {
-  region = data.aws_region.current.id
-  alias  = "default"
-}
+# provider "aws" {
+#   region = data.aws_region.current.id
+#   alias  = "default"
+# }
 
-provider "kubernetes" {
-  experiments {
-    manifest_resource = true
-  }
-  host                   = data.aws_eks_cluster.cluster.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
-  token                  = data.aws_eks_cluster_auth.cluster.token
-}
+# provider "kubernetes" {
+#   experiments {
+#     manifest_resource = true
+#   }
+#   host                   = data.aws_eks_cluster.cluster.endpoint
+#   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+#   token                  = data.aws_eks_cluster_auth.cluster.token
+# }
 
-provider "helm" {
-  kubernetes {
-    host                   = data.aws_eks_cluster.cluster.endpoint
-    token                  = data.aws_eks_cluster_auth.cluster.token
-    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
-  }
-}
+# provider "helm" {
+#   kubernetes {
+#     host                   = data.aws_eks_cluster.cluster.endpoint
+#     token                  = data.aws_eks_cluster_auth.cluster.token
+#     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+#   }
+# }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- E2E Adding depends on compute resources (can be the whole module) before installing any addons
- Disabling (commenting out the code for now) providers from addons module - following https://www.terraform.io/language/modules/develop/providers#legacy-shared-modules-with-provider-configurations instead
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
