### PR TITLE
fix prometheus values.yaml to remove breaking config

### DIFF
--- a/deploy/2-eks-cluster-with-import-vpc/eks/README.md
+++ b/deploy/2-eks-cluster-with-import-vpc/eks/README.md
@@ -44,6 +44,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 | Name | Type |
 |------|------|
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_eks_cluster_auth.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs

--- a/modules/kubernetes-addons/prometheus/values.yaml
+++ b/modules/kubernetes-addons/prometheus/values.yaml
@@ -1,27 +1,10 @@
 server:
   retention: 1h
-  remoteWrite:
-    - queue_config:
-        max_samples_per_send: 1000
-        max_shards: 200
-        capacity: 2500
 
   resources:
     requests:
       cpu: 500m
       memory: 512Mi
-
-  verticalAutoscaler:
-    enabled: true
-    updateMode: "Auto"
-    containerPolicies:
-      - containerName: "prometheus-server"
-        minAllowed:
-          cpu: 500m
-          memory: 512Mi
-        maxAllowed:
-          cpu: 1000m
-          memory: 2048Mi
 
   global:
     scrape_interval: 15s


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removing default configuration for `remoteWrite` and `verticalPodAutoscaler`. If we need the VPA config then we need to create an explicit dependency  between the two addons.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
