### PR TITLE
fix: deploy vpc_cni windows configmap if needed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -110,6 +110,7 @@ module "emr_on_eks" {
 }
 
 resource "kubernetes_config_map" "amazon_vpc_cni" {
+  count = var.enable_windows_support ? 1 : 0
   metadata {
     name      = "amazon-vpc-cni"
     namespace = "kube-system"
@@ -120,6 +121,7 @@ resource "kubernetes_config_map" "amazon_vpc_cni" {
   }
 
   depends_on = [
-    module.aws_eks
+    module.aws_eks,
+    data.http.eks_cluster_readiness[0]
   ]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Deploy VPC CNI windows configmap only when needed
- configmap resource should wait until EKS API endoint is ready (depends on)

This is a temp solution as we may move this resource outside the `main.tf` file
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
