### PR TITLE
test: add kubectl provider team example

### DIFF
--- a/examples/7-eks-cluster-with-teams/main.tf
+++ b/examples/7-eks-cluster-with-teams/main.tf
@@ -59,6 +59,13 @@ provider "helm" {
   }
 }
 
+provider "kubectl" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+  load_config_file       = false
+}
+
 locals {
   tenant      = "teams-account" # AWS account name or unique id for tenant
   environment = "sandbox"       # Environment area eg., preprod or prod


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- adding missing kubectl provider block, ensuring kubectl is not using local kube config

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
