### PR TITLE
test: add missing cluster_name addons example

### DIFF
--- a/examples/8-eks-cluster-with-eks-addons/main.tf
+++ b/examples/8-eks-cluster-with-eks-addons/main.tf
@@ -64,6 +64,7 @@ locals {
   vpc_cidr       = "10.0.0.0/16"
   vpc_name       = join("-", [local.tenant, local.environment, local.zone, "vpc"])
   eks_cluster_id = join("-", [local.tenant, local.environment, local.zone, "eks"])
+  cluster_name   = join("-", [local.tenant, local.environment, local.zone, "eks"])
 
   terraform_version = "Terraform v1.0.1"
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- add missing local `cluster_name` in the addons example

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
