### PR TITLE
refactor: platform team aws_iam_policy_document

### DIFF
--- a/modules/aws-eks-teams/data.tf
+++ b/modules/aws-eks-teams/data.tf
@@ -7,3 +7,28 @@ data "aws_eks_cluster" "eks_cluster" {
 }
 
 data "aws_partition" "current" {}
+
+data "aws_iam_policy_document" "platform_team_eks_access" {
+  statement {
+    sid = "AllowPlatformTeamEKSAccess"
+    actions = [
+      "eks:DescribeNodegroup",
+      "eks:ListNodegroups",
+      "eks:DescribeCluster",
+      "eks:ListClusters",
+      "eks:AccessKubernetesApi",
+      "ssm:GetParameter",
+      "eks:ListUpdates",
+      "eks:ListFargateProfiles"
+    ]
+    resources = [
+      data.aws_eks_cluster.eks_cluster.arn
+    ]
+  }
+
+  statement {
+    sid       = "AllowListClusters"
+    actions   = ["eks:ListClusters"]
+    resources = ["*"]
+  }
+}

--- a/modules/aws-eks-teams/main.tf
+++ b/modules/aws-eks-teams/main.tf
@@ -212,29 +212,5 @@ resource "aws_iam_policy" "platform_team_eks_access" {
   name        = format("%s-%s", local.role_prefix_name, "PlatformTeamEKSAccess")
   path        = "/"
   description = "Platform Team EKS Console Access"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = [
-          "eks:DescribeNodegroup",
-          "eks:ListNodegroups",
-          "eks:DescribeCluster",
-          "eks:ListClusters",
-          "eks:AccessKubernetesApi",
-          "ssm:GetParameter",
-          "eks:ListUpdates",
-          "eks:ListFargateProfiles"
-        ]
-        Effect   = "Allow"
-        Resource = data.aws_eks_cluster.eks_cluster.arn
-        }, {
-        Action = [
-          "eks:ListClusters",
-        ]
-        Effect   = "Allow"
-        Resource = "*"
-      }
-    ]
-  })
+  policy      = data.aws_iam_policy_document.platform_team_eks_access.json
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- refactor to use TF data `aws_iam_policy_document` instead of jsonencode for platform team

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
