### PR TITLE
Upgrade yunikorn version

### DIFF
--- a/docs/add-ons/keda.md
+++ b/docs/add-ons/keda.md
@@ -24,7 +24,7 @@ Deploy KEDA with custom `values.yaml`
     name       = "keda"                                               # (Required) Release name.
     repository = "https://kedacore.github.io/charts"                  # (Optional) Repository URL where to locate the requested chart.
     chart      = "keda"                                               # (Required) Chart name to be installed.
-    version    = "2.4.0"                                              # (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
+    version    = "2.4.0"                                              # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config in modules/kubernetes-addons/keda/locals.tf
     namespace  = "keda"                                               # (Optional) The namespace to install the release into. Defaults to default
     values = [templatefile("${path.module}/keda-values.yaml", {})]
   }

--- a/docs/add-ons/prometheus.md
+++ b/docs/add-ons/prometheus.md
@@ -32,7 +32,7 @@ Enable Prometheus with custom `values.yaml`
     name       = "prometheus"                                         # (Required) Release name.
     repository = "https://prometheus-community.github.io/helm-charts" # (Optional) Repository URL where to locate the requested chart.
     chart      = "prometheus"                                         # (Required) Chart name to be installed.
-    version    = "14.4.0"                                             # (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
+    version    = "14.4.0"                                             # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config in modules/kubernetes-addons/prometheus/locals.tf
     namespace  = "prometheus"                                         # (Optional) The namespace to install the release into. Defaults to default
     values = [templatefile("${path.module}/prometheus-values.yaml", {
       operating_system = "linux"

--- a/docs/add-ons/vpa.md
+++ b/docs/add-ons/vpa.md
@@ -20,7 +20,7 @@ Alternatively, you can override the helm values by using the code snippet below
     name       = "vpa"                                 # (Required) Release name.
     repository = "https://charts.fairwinds.com/stable" # (Optional) Repository URL where to locate the requested chart.
     chart      = "vpa"                                 # (Required) Chart name to be installed.
-    version    = "0.5.0"                               # (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
+    version    = "0.5.0"                               # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config in modules/kubernetes-addons/vpa/locals.tf
     namespace  = "vpa-ns"                              # (Optional) The namespace to install the release into. Defaults to default
     values     = [templatefile("${path.module}/values.yaml", {})]
   }

--- a/docs/add-ons/yunikorn.md
+++ b/docs/add-ons/yunikorn.md
@@ -21,7 +21,7 @@ Alternatively, you can override the helm values by using the code snippet below
     name       = "yunikorn"                                 # (Required) Release name.
     repository = "https://apache.github.io/incubator-yunikorn-release" # (Optional) Repository URL where to locate the requested chart.
     chart      = "yunikorn"                                 # (Required) Chart name to be installed.
-    version    = "0.12.0"                               # (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
+    version    = "0.12.0"                               # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config in modules/kubernetes-addons/yunikorn/locals.tf
     values     = [templatefile("${path.module}/values.yaml", {})]
   }
 ```

--- a/modules/kubernetes-addons/yunikorn/locals.tf
+++ b/modules/kubernetes-addons/yunikorn/locals.tf
@@ -23,7 +23,7 @@ locals {
     name                       = "yunikorn"
     chart                      = "yunikorn"
     repository                 = "https://apache.github.io/incubator-yunikorn-release"
-    version                    = "0.11.0"
+    version                    = "0.12.2"
     namespace                  = "yunikorn"
     timeout                    = "1200"
     create_namespace           = true


### PR DESCRIPTION


### What does this PR do?

Upgrades yunikorn from 0.11.0 to 0.12.2 and removes comments from all k8s addon documentation that says it defaults to the latest version if the version number is not specified. 


### Motivation

Upgrading 

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [x] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable) 
  - https://github.com/aws-samples/ssp-eks-add-ons/pull/7
- [x] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

Testing notes:
  - created test directory and filled main.tf file with vpc, eks cluster with yunikorn enabled
  - `terraform apply -auto-approve` and check that deployment completes
  - Connected to cluster and verify that nodes are online
  - Accessed the webui and verified page loads:
    - `kubectl port-forward svc/yunikorn-service 9889:9889 -n yunikorn`
    - connected to http://localhost:9889 without issue
