### PR TITLE
Feature/upgrade-vpa

### DIFF
--- a/docs/add-ons/keda.md
+++ b/docs/add-ons/keda.md
@@ -24,7 +24,7 @@ Deploy KEDA with custom `values.yaml`
     name       = "keda"                                               # (Required) Release name.
     repository = "https://kedacore.github.io/charts"                  # (Optional) Repository URL where to locate the requested chart.
     chart      = "keda"                                               # (Required) Chart name to be installed.
-    version    = "2.4.0"                                              # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config in modules/kubernetes-addons/keda/locals.tf
+    version    = "2.4.0"                                              # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config: https://github.com/aws-samples/aws-eks-accelerator-for-terraform/blob/main/modules/kubernetes-addons/keda/locals.tf
     namespace  = "keda"                                               # (Optional) The namespace to install the release into. Defaults to default
     values = [templatefile("${path.module}/keda-values.yaml", {})]
   }

--- a/docs/add-ons/prometheus.md
+++ b/docs/add-ons/prometheus.md
@@ -32,7 +32,7 @@ Enable Prometheus with custom `values.yaml`
     name       = "prometheus"                                         # (Required) Release name.
     repository = "https://prometheus-community.github.io/helm-charts" # (Optional) Repository URL where to locate the requested chart.
     chart      = "prometheus"                                         # (Required) Chart name to be installed.
-    version    = "14.4.0"                                             # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config in modules/kubernetes-addons/prometheus/locals.tf
+    version    = "14.4.0"                                             # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config: https://github.com/aws-samples/aws-eks-accelerator-for-terraform/blob/main/modules/kubernetes-addons/prometheus/locals.tf
     namespace  = "prometheus"                                         # (Optional) The namespace to install the release into. Defaults to default
     values = [templatefile("${path.module}/prometheus-values.yaml", {
       operating_system = "linux"

--- a/docs/add-ons/vpa.md
+++ b/docs/add-ons/vpa.md
@@ -20,7 +20,7 @@ Alternatively, you can override the helm values by using the code snippet below
     name       = "vpa"                                 # (Required) Release name.
     repository = "https://charts.fairwinds.com/stable" # (Optional) Repository URL where to locate the requested chart.
     chart      = "vpa"                                 # (Required) Chart name to be installed.
-    version    = "0.5.0"                               # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config in modules/kubernetes-addons/vpa/locals.tf
+    version    = "0.5.0"                               # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config: https://github.com/aws-samples/aws-eks-accelerator-for-terraform/blob/main/modules/kubernetes-addons/vpa/locals.tf
     namespace  = "vpa-ns"                              # (Optional) The namespace to install the release into. Defaults to default
     values     = [templatefile("${path.module}/values.yaml", {})]
   }

--- a/docs/add-ons/yunikorn.md
+++ b/docs/add-ons/yunikorn.md
@@ -21,7 +21,7 @@ Alternatively, you can override the helm values by using the code snippet below
     name       = "yunikorn"                                 # (Required) Release name.
     repository = "https://apache.github.io/incubator-yunikorn-release" # (Optional) Repository URL where to locate the requested chart.
     chart      = "yunikorn"                                 # (Required) Chart name to be installed.
-    version    = "0.12.0"                               # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config in modules/kubernetes-addons/yunikorn/locals.tf
+    version    = "0.12.0"                               # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config: https://github.com/aws-samples/aws-eks-accelerator-for-terraform/blob/main/modules/kubernetes-addons/yunikorn/locals.tf
     values     = [templatefile("${path.module}/values.yaml", {})]
   }
 ```

--- a/modules/kubernetes-addons/vpa/locals.tf
+++ b/modules/kubernetes-addons/vpa/locals.tf
@@ -24,7 +24,7 @@ locals {
     name                       = "vpa"
     chart                      = "vpa"
     repository                 = "https://charts.fairwinds.com/stable"
-    version                    = "0.5.0"
+    version                    = "1.0.0"
     namespace                  = "vpa-ns"
     timeout                    = "1200"
     create_namespace           = true

--- a/modules/kubernetes-addons/vpa/values.yaml
+++ b/modules/kubernetes-addons/vpa/values.yaml
@@ -5,13 +5,13 @@ serviceAccount:
 recommender:
   image:
     repository: k8s.gcr.io/autoscaling/vpa-recommender
-    tag: "0.9.0"       #  This tag supports autoscaling.k8s.io/v1beta2. Prometheus Helm chart VPA only supports autoscaling.k8s.io/v1beta2 hence we are aligning both
+    tag: "0.9.2" #  This tag supports autoscaling.k8s.io/v1beta2. Prometheus Helm chart VPA only supports autoscaling.k8s.io/v1beta2 hence we are aligning both
   nodeSelector:
     kubernetes.io/os: linux
 
 updater:
   image:
     repository: k8s.gcr.io/autoscaling/vpa-updater
-    tag: "0.9.0"       #  This tag supports autoscaling.k8s.io/v1beta2. Prometheus Helm chart VPA only supports autoscaling.k8s.io/v1beta2 hence we are aligning both
+    tag: "0.9.2" #  This tag supports autoscaling.k8s.io/v1beta2. Prometheus Helm chart VPA only supports autoscaling.k8s.io/v1beta2 hence we are aligning both
   nodeSelector:
     kubernetes.io/os: linux


### PR DESCRIPTION
### What does this PR do?

Updates the helm chart for VPA to the latest version: 0.5.0 -> 1.0.0
Also updates the default recommender and updater image tags to the latest, from 0.9.0 -> 0.9.2
Finally, updates the links in the docs for addons: keda, prometheus, vpa, and yunikorn.


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [x] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
  - https://github.com/aws-samples/ssp-eks-add-ons/pull/8
- [x] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes
Testing notes:
  - created test directory and filled main.tf file with vpc, eks cluster with vpa and metrics server enabled
  - ran `terraform apply -auto-approve` and checked that deployment completes
  - connected to cluster and verified that nodes are online
  - ran test deployment with quick start from https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/examples/hamster.yaml
      - ran `kubectl create -f examples/hamster.yaml`
      - ran `kubectl describe vpa` to check that configuration has been updated
