### PR TITLE
 aws-opentelemetry-eks allow user overrides for addon_config

### DIFF
--- a/modules/kubernetes-addons/aws-opentelemetry-eks/main.tf
+++ b/modules/kubernetes-addons/aws-opentelemetry-eks/main.tf
@@ -19,10 +19,10 @@
 resource "kubernetes_namespace" "aws_otel_eks" {
   count = var.manage_via_gitops ? 0 : 1
   metadata {
-    name = local.default_addon_config["namespace"]
+    name = local.addon_config["namespace"]
 
     labels = {
-      name = local.default_addon_config["namespace"]
+      name = local.addon_config["namespace"]
     }
   }
 }
@@ -31,7 +31,7 @@ resource "kubernetes_deployment" "aws_otel_eks_sidecar" {
   count = var.manage_via_gitops ? 0 : 1
   metadata {
     name      = "aws-otel-eks-sidecar"
-    namespace = local.default_addon_config["namespace"]
+    namespace = local.addon_config["namespace"]
 
     labels = {
       name = "aws-otel-eks-sidecar"
@@ -56,22 +56,22 @@ resource "kubernetes_deployment" "aws_otel_eks_sidecar" {
 
       spec {
         container {
-          name  = local.default_addon_config["emitter_name"]
-          image = local.default_addon_config["emitter_image"]
+          name  = local.addon_config["emitter_name"]
+          image = local.addon_config["emitter_image"]
 
           env {
             name  = "OTEL_OTLP_ENDPOINT"
-            value = local.default_addon_config["emitter_oltp_endpoint"]
+            value = local.addon_config["emitter_oltp_endpoint"]
           }
 
           env {
             name  = "OTEL_RESOURCE_ATTRIBUTES"
-            value = local.default_addon_config["emitter_otel_resource_attributes"]
+            value = local.addon_config["emitter_otel_resource_attributes"]
           }
 
           env {
             name  = "S3_REGION"
-            value = local.default_addon_config["aws_region"]
+            value = local.addon_config["aws_region"]
           }
 
           image_pull_policy = "Always"
@@ -79,11 +79,11 @@ resource "kubernetes_deployment" "aws_otel_eks_sidecar" {
 
         container {
           name  = "aws-otel-collector"
-          image = local.default_addon_config["collector_image"]
+          image = local.addon_config["collector_image"]
 
           env {
             name  = "AWS_REGION"
-            value = local.default_addon_config["aws_region"]
+            value = local.addon_config["aws_region"]
           }
 
           resources {

--- a/modules/kubernetes-addons/aws-opentelemetry-eks/main.tf
+++ b/modules/kubernetes-addons/aws-opentelemetry-eks/main.tf
@@ -55,6 +55,11 @@ resource "kubernetes_deployment" "aws_otel_eks_sidecar" {
       }
 
       spec {
+        
+        node_selector = {
+          "kubernetes.io/os" = "linux"
+        }  
+        
         container {
           name  = local.addon_config["emitter_name"]
           image = local.addon_config["emitter_image"]


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
