### PR TITLE
Karpenter example with default provisioner

### DIFF
--- a/examples/karpenter/README.md
+++ b/examples/karpenter/README.md
@@ -91,6 +91,7 @@ terraform destroy
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.66.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.13.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.6.1 |
 
 ## Providers
@@ -98,6 +99,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.66.0 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 1.13.1 |
 
 ## Modules
 
@@ -112,10 +114,12 @@ terraform destroy
 
 | Name | Type |
 |------|------|
+| [kubectl_manifest.karpenter_provisioner](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_eks_cluster_auth.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [kubectl_path_documents.karpenter_provisioners](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/path_documents) | data source |
 
 ## Inputs
 

--- a/examples/karpenter/README.md
+++ b/examples/karpenter/README.md
@@ -8,6 +8,7 @@ This example shows how to deploy and leverage Karpenter for Autoscaling. The fol
  - Creates Internet gateway for Public Subnets and NAT Gateway for Private Subnets
  - Creates EKS Cluster Control plane with one Self-managed node group with Max ASG of 1
  - Deploys Karpenter Helm Chart
+ - Deploys default Karpenter Provisioner
 
 # How to Deploy
 ## Prerequisites:
@@ -72,19 +73,11 @@ You should see one Self-managed node up and running
       karpenter-controller-5f959cdc44-8dmjb   1/1     Running   0          31m
       karpenter-webhook-65f48f8d49-5hkpb      1/1     Running   0          31m
 
-#### Step8: Deploy the default provisioner
-Kaprpenter will be ready to spin up SPOT/ON-DEMAND nodes based on the provided configuraiton in `default_provisioner.yaml`
-
-    $ cd examples/eks-cluster-with-karpenter/provisioners
-    $ kubectl apply -f default_provisioner.yaml
-
-#### Step9: Run this sample `deployment` to verify the Autoscaling triggered by Karpenter
-
-    $ cd examples/eks-cluster-with-karpenter/provisioners
-    $ kubectl apply -f sample_deployment.yaml
-
-
 # How to Destroy
+
+NOTE: Make sure you delete all the deployments which clean up the nodes spun up by Karpenter Autoscaler
+Ensure no nodes are running created by Karpenter before running the `Terraform Destroy`. Otherwise, EKS Cluster will be cleaned up however this may leave some nodes running in EC2.
+
 ```shell script
 cd examples/eks-cluster-with-karpenter
 terraform destroy

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -190,17 +190,18 @@ module "kubernetes-addons" {
 
 # Deploying default provisioner for Karpenter autoscaler
 data "kubectl_path_documents" "karpenter_provisioners" {
-  pattern = "${path.module}/karpenter-provisioners/default-provisioner.yaml"
+  pattern = "${path.module}/provisioners/default_provisioner.yaml"
   vars = {
-    azs                     = local.azs
+    azs                     = join(",", local.azs)
     iam-instance-profile-id = format("%s-%s", local.cluster_name, local.node_group_name)
+    eks-cluster-id          = local.cluster_name
   }
 }
 
 # You can also deploy multiple provisioner files with the below code snippet
-//data "kubectl_path_documents" "karpenter_provisioners" {
-//  pattern = "${path.module}/karpenter-provisioners/*.yaml"
-//}
+# data "kubectl_path_documents" "karpenter_provisioners" {
+#   pattern = "${path.module}/provisioners/*.yaml"
+# }
 
 resource "kubectl_manifest" "karpenter_provisioner" {
   for_each  = toset(data.kubectl_path_documents.karpenter_provisioners.documents)

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -14,6 +14,10 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 2.4.1"
     }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.13.1"
+    }
   }
 
   backend "local" {
@@ -55,16 +59,26 @@ provider "helm" {
   }
 }
 
+provider "kubectl" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+  load_config_file       = false
+  apply_retry_count      = 10
+}
+
 locals {
   tenant      = "aws001"  # AWS account name or unique id for tenant
   environment = "preprod" # Environment area eg., preprod or prod
   zone        = "dev"     # Environment with in one sub_tenant or business unit
+  azs         = data.aws_availability_zones.available.names
 
   kubernetes_version = "1.21"
 
   vpc_cidr     = "10.0.0.0/16"
   vpc_name     = join("-", [local.tenant, local.environment, local.zone, "vpc"])
   cluster_name = join("-", [local.tenant, local.environment, local.zone, "eks"])
+  node_group_name = "self-ondemand"
 
   terraform_version = "Terraform v1.0.1"
 }
@@ -75,7 +89,7 @@ module "aws_vpc" {
 
   name = local.vpc_name
   cidr = local.vpc_cidr
-  azs  = data.aws_availability_zones.available.names
+  azs  = local.azs
 
   public_subnets  = [for k, v in data.aws_availability_zones.available.names : cidrsubnet(local.vpc_cidr, 8, k)]
   private_subnets = [for k, v in data.aws_availability_zones.available.names : cidrsubnet(local.vpc_cidr, 8, k + 10)]
@@ -118,7 +132,7 @@ module "aws-eks-accelerator-for-terraform" {
   # Karpenter requires one node to get up and running
   self_managed_node_groups = {
     self_mg_4 = {
-      node_group_name    = "self-managed-ondemand"
+      node_group_name    = local.node_group_name
       launch_template_os = "amazonlinux2eks"
       max_size           = 1
       subnet_ids         = module.aws_vpc.private_subnets
@@ -167,9 +181,32 @@ module "kubernetes-addons" {
   source = "../../modules/kubernetes-addons"
 
   eks_cluster_id = module.aws-eks-accelerator-for-terraform.eks_cluster_id
-  #K8s Add-ons
+
+  # Deploys Karpenter add-on
   enable_karpenter      = true
-  enable_metrics_server = true
 
   depends_on = [module.aws-eks-accelerator-for-terraform.self_managed_node_groups]
 }
+
+# Deploying default provisioner for Karpenter autoscaler
+data "kubectl_path_documents" "karpenter_provisioners" {
+  pattern = "${path.module}/karpenter-provisioners/default-provisioner.yaml"
+  vars = {
+    azs = local.azs
+    iam-instance-profile-id = format("%s-%s", local.cluster_name, local.node_group_name)
+  }
+}
+
+# You can also deploy multiple provisioner files with the below code snippet
+//data "kubectl_path_documents" "karpenter_provisioners" {
+//  pattern = "${path.module}/karpenter-provisioners/*.yaml"
+//}
+
+resource "kubectl_manifest" "karpenter_provisioner" {
+  for_each  = toset(data.kubectl_path_documents.karpenter_provisioners.documents)
+  yaml_body = each.value
+
+  depends_on = [module.kubernetes-addons]
+}
+
+

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -75,9 +75,9 @@ locals {
 
   kubernetes_version = "1.21"
 
-  vpc_cidr     = "10.0.0.0/16"
-  vpc_name     = join("-", [local.tenant, local.environment, local.zone, "vpc"])
-  cluster_name = join("-", [local.tenant, local.environment, local.zone, "eks"])
+  vpc_cidr        = "10.0.0.0/16"
+  vpc_name        = join("-", [local.tenant, local.environment, local.zone, "vpc"])
+  cluster_name    = join("-", [local.tenant, local.environment, local.zone, "eks"])
   node_group_name = "self-ondemand"
 
   terraform_version = "Terraform v1.0.1"
@@ -183,7 +183,7 @@ module "kubernetes-addons" {
   eks_cluster_id = module.aws-eks-accelerator-for-terraform.eks_cluster_id
 
   # Deploys Karpenter add-on
-  enable_karpenter      = true
+  enable_karpenter = true
 
   depends_on = [module.aws-eks-accelerator-for-terraform.self_managed_node_groups]
 }
@@ -192,7 +192,7 @@ module "kubernetes-addons" {
 data "kubectl_path_documents" "karpenter_provisioners" {
   pattern = "${path.module}/karpenter-provisioners/default-provisioner.yaml"
   vars = {
-    azs = local.azs
+    azs                     = local.azs
     iam-instance-profile-id = format("%s-%s", local.cluster_name, local.node_group_name)
   }
 }
@@ -208,5 +208,3 @@ resource "kubectl_manifest" "karpenter_provisioner" {
 
   depends_on = [module.kubernetes-addons]
 }
-
-

--- a/examples/karpenter/provisioners/default_provisioner.yaml
+++ b/examples/karpenter/provisioners/default_provisioner.yaml
@@ -6,7 +6,7 @@ spec:
   requirements:
     - key: "topology.kubernetes.io/zone"
       operator: In
-      values: ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+      values: ${azs}
     - key: "karpenter.sh/capacity-type"
       operator: In
       values: ["spot", "on-demand"]
@@ -14,8 +14,8 @@ spec:
     resources:
       cpu: 1000
   provider:
-    instanceProfile: "aws001-preprod-dev-eks-self-managed-ondemand" # self-managed IAM Instance profile Name
-#    launchTemplate: MyLaunchTemplate   # Optional to provide Launch template
+    instanceProfile: ${iam-instance-profile-id}
     subnetSelector:
       Name: "*private*"
-  ttlSecondsAfterEmpty: 30
+  ttlSecondsAfterEmpty: 120
+

--- a/examples/karpenter/provisioners/default_provisioner.yaml
+++ b/examples/karpenter/provisioners/default_provisioner.yaml
@@ -18,4 +18,3 @@ spec:
     subnetSelector:
       Name: "*private*"
   ttlSecondsAfterEmpty: 120
-

--- a/examples/karpenter/provisioners/default_provisioner.yaml
+++ b/examples/karpenter/provisioners/default_provisioner.yaml
@@ -6,7 +6,7 @@ spec:
   requirements:
     - key: "topology.kubernetes.io/zone"
       operator: In
-      values: ${azs}
+      values: [${azs}]
     - key: "karpenter.sh/capacity-type"
       operator: In
       values: ["spot", "on-demand"]
@@ -17,4 +17,6 @@ spec:
     instanceProfile: ${iam-instance-profile-id}
     subnetSelector:
       Name: "*private*"
+    securityGroupSelector:
+      kubernetes.io/cluster/${eks-cluster-id}: 'owned'
   ttlSecondsAfterEmpty: 120


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- This example shows a pattern on how to deploy multiple Karpenter Cluster Autoscaler Provisioners

### Motivation

<!-- What inspired you to submit this pull request? -->
- Users feedback on Karpenter to manage provisioners using Terraform

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
