### PR TITLE
Terraform plan removed from e2e test workflow

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -52,17 +52,11 @@ jobs:
           run: terraform validate -no-color
           continue-on-error: false
 
-        - name: Terraform Plan
-          id: plan
-          working-directory: deploy/e2e/eks
-          run: terraform plan -var-file base.tfvars -no-color
-          continue-on-error: false
-
         - name: Terraform Apply
           id: apply
           working-directory: deploy/e2e/eks
-          run: terraform apply -var-file base.tfvars -no-color -auto-approve
-          continue-on-error: true
+          run: terraform apply -var-file base.tfvars -no-color -input=false -auto-approve
+          continue-on-error: false
 
         - name: Terraform Destroy
           if: github.event.inputs.TFDestroy == 'true' && (steps.apply.outcome == 'success' || steps.apply.outcome == 'failure')


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

- This variant of the `apply` command `implicitly creates a new plan` and then immediately applies it. The -auto-approve option tells Terraform not to require interactive approval of the plan before applying it.

### Motivation

<!-- What inspired you to submit this pull request? -->

- This will reduce the E2E tests time up to 7 mins.

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [x] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
