### PR TITLE
Fix/workers and aws-auth depends_on - improve TF plan time

### DIFF
--- a/eks-worker.tf
+++ b/eks-worker.tf
@@ -43,6 +43,8 @@ module "aws_eks_managed_node_groups" {
   cluster_security_group_id            = module.aws_eks.cluster_security_group_id
   cluster_primary_security_group_id    = module.aws_eks.cluster_primary_security_group_id
   tags                                 = module.eks_tags.tags
+
+  depends_on = [kubernetes_config_map.aws_auth]
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -72,6 +74,8 @@ module "aws_eks_self_managed_node_groups" {
   cluster_security_group_id            = module.aws_eks.cluster_security_group_id
   cluster_primary_security_group_id    = module.aws_eks.cluster_primary_security_group_id
   tags                                 = module.eks_tags.tags
+
+  depends_on = [kubernetes_config_map.aws_auth]
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -86,4 +90,6 @@ module "aws_eks_fargate_profiles" {
   fargate_profile = each.value
   eks_cluster_id  = module.aws_eks.cluster_id
   tags            = module.eks_tags.tags
+
+  depends_on = [kubernetes_config_map.aws_auth]
 }

--- a/eks-worker.tf
+++ b/eks-worker.tf
@@ -43,8 +43,6 @@ module "aws_eks_managed_node_groups" {
   cluster_security_group_id            = module.aws_eks.cluster_security_group_id
   cluster_primary_security_group_id    = module.aws_eks.cluster_primary_security_group_id
   tags                                 = module.eks_tags.tags
-
-# depends_on = [module.aws_eks, kubernetes_config_map.aws_auth]
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/eks-worker.tf
+++ b/eks-worker.tf
@@ -72,8 +72,6 @@ module "aws_eks_self_managed_node_groups" {
   cluster_security_group_id            = module.aws_eks.cluster_security_group_id
   cluster_primary_security_group_id    = module.aws_eks.cluster_primary_security_group_id
   tags                                 = module.eks_tags.tags
-
-  depends_on = [module.aws_eks, kubernetes_config_map.aws_auth]
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -88,6 +86,4 @@ module "aws_eks_fargate_profiles" {
   fargate_profile = each.value
   eks_cluster_id  = module.aws_eks.cluster_id
   tags            = module.eks_tags.tags
-
-  depends_on = [module.aws_eks, kubernetes_config_map.aws_auth]
 }

--- a/eks-worker.tf
+++ b/eks-worker.tf
@@ -44,7 +44,7 @@ module "aws_eks_managed_node_groups" {
   cluster_primary_security_group_id    = module.aws_eks.cluster_primary_security_group_id
   tags                                 = module.eks_tags.tags
 
-  depends_on = [module.aws_eks, kubernetes_config_map.aws_auth]
+# depends_on = [module.aws_eks, kubernetes_config_map.aws_auth]
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/eks-cluster-with-import-vpc/eks/main.tf
+++ b/examples/eks-cluster-with-import-vpc/eks/main.tf
@@ -102,5 +102,5 @@ module "kubernetes-addons" {
   enable_fargate_fluentbit            = false
   enable_argo_rollouts                = true
 
-  # depends_on = [module.aws-eks-accelerator-for-terraform.managed_node_groups]
+  depends_on = [module.aws-eks-accelerator-for-terraform.managed_node_groups]
 }

--- a/examples/eks-cluster-with-import-vpc/eks/main.tf
+++ b/examples/eks-cluster-with-import-vpc/eks/main.tf
@@ -102,5 +102,5 @@ module "kubernetes-addons" {
   enable_fargate_fluentbit            = false
   enable_argo_rollouts                = true
 
-  depends_on = [module.aws-eks-accelerator-for-terraform.managed_node_groups]
+  # depends_on = [module.aws-eks-accelerator-for-terraform.managed_node_groups]
 }

--- a/locals.tf
+++ b/locals.tf
@@ -81,7 +81,30 @@ locals {
     }
   ] : []
 
-  platform_teams_config_map    = module.aws_eks_teams.platform_teams_config_map
-  application_teams_config_map = module.aws_eks_teams.application_teams_config_map
-  cluster_iam_role_name        = "${module.eks_tags.tags.name}-cluster-role"
+  # Teams
+  role_prefix_name = format("%s-%s-%s", var.tenant, var.environment, var.zone)
+  partition        = data.aws_partition.current.partition
+  account_id       = data.aws_caller_identity.current.account_id
+
+  platform_teams_config_map = length(var.platform_teams) > 0 ? [
+    for platform_team_name, platform_team_data in var.platform_teams : {
+      rolearn : "arn:${local.partition}:iam::${local.account_id}:role/${format("%s-%s-%s", local.role_prefix_name, "${platform_team_name}", "Access")}"
+      username : "${platform_team_name}"
+      groups : [
+        "system:masters"
+      ]
+    }
+  ] : []
+
+  application_teams_config_map = length(var.application_teams) > 0 ? [
+    for team_name, team_data in var.application_teams : {
+      rolearn : "arn:${local.partition}:iam::${local.account_id}:role/${format("%s-%s-%s", local.role_prefix_name, "${team_name}", "Access")}"
+      username : "${team_name}"
+      groups : [
+        "${team_name}-group"
+      ]
+    }
+  ] : []
+
+  cluster_iam_role_name = "${module.eks_tags.tags.name}-cluster-role"
 }

--- a/modules/aws-eks-teams/README.md
+++ b/modules/aws-eks-teams/README.md
@@ -172,9 +172,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_application_teams_config_map"></a> [application\_teams\_config\_map](#output\_application\_teams\_config\_map) | Application Teams AWS Auth Configmap |
 | <a name="output_application_teams_iam_role_arn"></a> [application\_teams\_iam\_role\_arn](#output\_application\_teams\_iam\_role\_arn) | IAM role ARN for Teams |
-| <a name="output_platform_teams_config_map"></a> [platform\_teams\_config\_map](#output\_platform\_teams\_config\_map) | Platform Teams AWS Auth Configmap |
 | <a name="output_platform_teams_iam_role_arn"></a> [platform\_teams\_iam\_role\_arn](#output\_platform\_teams\_iam\_role\_arn) | IAM role ARN for Platform Teams |
 | <a name="output_team_sa_irsa_iam_role_arn"></a> [team\_sa\_irsa\_iam\_role\_arn](#output\_team\_sa\_irsa\_iam\_role\_arn) | IAM role ARN for Teams EKS Service Account (IRSA) |
 

--- a/modules/aws-eks-teams/locals.tf
+++ b/modules/aws-eks-teams/locals.tf
@@ -10,24 +10,4 @@ locals {
     try(fileset(path.root, "${team_data.manifests_dir}/*"), [])
   ])
 
-  platform_teams_config_map = length(var.platform_teams) > 0 ? [
-    for platform_team_name, platform_team_data in var.platform_teams : {
-      rolearn : "arn:${local.partition}:iam::${local.account_id}:role/${format("%s-%s-%s", local.role_prefix_name, "${platform_team_name}", "Access")}"
-      username : "${platform_team_name}"
-      groups : [
-        "system:masters"
-      ]
-    }
-  ] : []
-
-  application_teams_config_map = length(var.application_teams) > 0 ? [
-    for team_name, team_data in var.application_teams : {
-      rolearn : "arn:${local.partition}:iam::${local.account_id}:role/${format("%s-%s-%s", local.role_prefix_name, "${team_name}", "Access")}"
-      username : "${team_name}"
-      groups : [
-        "${team_name}-group"
-      ]
-    }
-  ] : []
-
 }

--- a/modules/aws-eks-teams/outputs.tf
+++ b/modules/aws-eks-teams/outputs.tf
@@ -18,13 +18,3 @@ output "team_sa_irsa_iam_role_arn" {
     for k, v in aws_iam_role.team_sa_irsa : k => v.arn
   })
 }
-
-output "application_teams_config_map" {
-  description = "Application Teams AWS Auth Configmap"
-  value       = local.application_teams_config_map
-}
-
-output "platform_teams_config_map" {
-  description = "Platform Teams AWS Auth Configmap"
-  value       = local.platform_teams_config_map
-}

--- a/modules/kubernetes-addons/argo-rollouts/locals.tf
+++ b/modules/kubernetes-addons/argo-rollouts/locals.tf
@@ -9,6 +9,7 @@ locals {
     namespace   = local.name
     description = "Argo Rollouts AddOn Helm Chart"
     values      = local.default_helm_values
+    timeout     = "1200"
   }
 
   default_helm_values = [templatefile("${path.module}/values.yaml", {

--- a/modules/kubernetes-addons/cluster-autoscaler/locals.tf
+++ b/modules/kubernetes-addons/cluster-autoscaler/locals.tf
@@ -8,7 +8,7 @@ locals {
     repository                 = "https://kubernetes.github.io/autoscaler"
     version                    = "9.10.8"
     namespace                  = local.namespace
-    timeout                    = "300"
+    timeout                    = "1200"
     create_namespace           = false
     values                     = local.default_helm_values
     lint                       = false

--- a/modules/kubernetes-addons/prometheus/locals.tf
+++ b/modules/kubernetes-addons/prometheus/locals.tf
@@ -5,7 +5,7 @@ locals {
     repository                 = "https://prometheus-community.github.io/helm-charts"
     version                    = "14.6.0"
     namespace                  = "prometheus"
-    timeout                    = "300"
+    timeout                    = "1200"
     create_namespace           = false
     description                = "Prometheus helm Chart deployment configuration"
     lint                       = false


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- remove `depends_on` of the aws_auth and eks module from the worker which will speed up `terraform plan` times
- add  & adjust helm chart timeouts to reduce time out / context deadline failures 
### Motivation

<!-- What inspired you to submit this pull request? -->
- terraform plan takes longer than expected, `depends_on` is major functionality (explicit depndency) that increases the time of the TF plan

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
