### PR TITLE
fix: adding depndencies observability example

### DIFF
--- a/examples/observability/eks-cluster-with-amp-amg-opensearch/main.tf
+++ b/examples/observability/eks-cluster-with-amp-amg-opensearch/main.tf
@@ -136,7 +136,11 @@ module "kubernetes-addons" {
   enable_prometheus                    = true
   enable_amazon_prometheus             = true
   amazon_prometheus_workspace_endpoint = module.aws-eks-accelerator-for-terraform.amazon_prometheus_workspace_endpoint
-  depends_on                           = [module.aws-eks-accelerator-for-terraform.managed_node_groups, module.aws_vpc]
+
+  depends_on = [
+    module.aws-eks-accelerator-for-terraform.managed_node_groups,
+    module.aws_vpc
+  ]
 }
 
 #---------------------------------------------------------------

--- a/examples/observability/eks-cluster-with-amp-amg-opensearch/main.tf
+++ b/examples/observability/eks-cluster-with-amp-amg-opensearch/main.tf
@@ -136,7 +136,7 @@ module "kubernetes-addons" {
   enable_prometheus                    = true
   enable_amazon_prometheus             = true
   amazon_prometheus_workspace_endpoint = module.aws-eks-accelerator-for-terraform.amazon_prometheus_workspace_endpoint
-  depends_on                           = [module.aws-eks-accelerator-for-terraform.managed_node_groups]
+  depends_on                           = [module.aws-eks-accelerator-for-terraform.managed_node_groups, module.aws_vpc]
 }
 
 #---------------------------------------------------------------
@@ -200,7 +200,7 @@ resource "aws_elasticsearch_domain" "opensearch" {
   }
 
   depends_on = [
-    aws_iam_service_linked_role.opensearch, module.aws_vpc
+    aws_iam_service_linked_role.opensearch
   ]
 }
 

--- a/examples/observability/eks-cluster-with-amp-amg-opensearch/main.tf
+++ b/examples/observability/eks-cluster-with-amp-amg-opensearch/main.tf
@@ -136,6 +136,7 @@ module "kubernetes-addons" {
   enable_prometheus                    = true
   enable_amazon_prometheus             = true
   amazon_prometheus_workspace_endpoint = module.aws-eks-accelerator-for-terraform.amazon_prometheus_workspace_endpoint
+  depends_on                           = [module.aws-eks-accelerator-for-terraform.managed_node_groups]
 }
 
 #---------------------------------------------------------------
@@ -197,6 +198,10 @@ resource "aws_elasticsearch_domain" "opensearch" {
     subnet_ids         = module.aws_vpc.public_subnets
     security_group_ids = [aws_security_group.opensearch_access.id]
   }
+
+  depends_on = [
+    aws_iam_service_linked_role.opensearch, module.aws_vpc
+  ]
 }
 
 resource "aws_iam_service_linked_role" "opensearch" {

--- a/modules/kubernetes-addons/aws-opentelemetry-eks/main.tf
+++ b/modules/kubernetes-addons/aws-opentelemetry-eks/main.tf
@@ -55,11 +55,11 @@ resource "kubernetes_deployment" "aws_otel_eks_sidecar" {
       }
 
       spec {
-        
+
         node_selector = {
           "kubernetes.io/os" = "linux"
-        }  
-        
+        }
+
         container {
           name  = local.addon_config["emitter_name"]
           image = local.addon_config["emitter_image"]


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Adding `depends_on` for observability example to correct resources flow creation (VPC -> Cluster -> Addons etc.)


### Motivation
- addressing https://github.com/aws-samples/aws-eks-accelerator-for-terraform/issues/267 issue(s)
- `aws_iam_service_linked_role` should be deleted only after the opensearch is deleted
- fixing failures around context deadlines and time outs for the example
<!-- What inspired you to submit this pull request? -->


### More

- [X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [X] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
