### PR TITLE
Update keda helm chart version

### DIFF
--- a/docs/add-ons/keda.md
+++ b/docs/add-ons/keda.md
@@ -24,7 +24,7 @@ Deploy KEDA with custom `values.yaml`
     name       = "keda"                                               # (Required) Release name.
     repository = "https://kedacore.github.io/charts"                  # (Optional) Repository URL where to locate the requested chart.
     chart      = "keda"                                               # (Required) Chart name to be installed.
-    version    = "2.4.0"                                              # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config: https://github.com/aws-samples/aws-eks-accelerator-for-terraform/blob/main/modules/kubernetes-addons/keda/locals.tf
+    version    = "2.6.2"                                              # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config: https://github.com/aws-samples/aws-eks-accelerator-for-terraform/blob/main/modules/kubernetes-addons/keda/locals.tf
     namespace  = "keda"                                               # (Optional) The namespace to install the release into. Defaults to default
     values = [templatefile("${path.module}/keda-values.yaml", {})]
   }

--- a/docs/add-ons/keda.md
+++ b/docs/add-ons/keda.md
@@ -25,7 +25,7 @@ Deploy KEDA with custom `values.yaml`
     repository = "https://kedacore.github.io/charts"                  # (Optional) Repository URL where to locate the requested chart.
     chart      = "keda"                                               # (Required) Chart name to be installed.
     version    = "2.6.2"                                              # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config: https://github.com/aws-samples/aws-eks-accelerator-for-terraform/blob/main/modules/kubernetes-addons/keda/locals.tf
-    namespace  = "keda"                                               # (Optional) The namespace to install the release into. Defaults to default
+    namespace  = "keda"                                               # (Optional) The namespace to install the release into.
     values = [templatefile("${path.module}/keda-values.yaml", {})]
   }
 ```

--- a/docs/add-ons/prometheus.md
+++ b/docs/add-ons/prometheus.md
@@ -33,7 +33,7 @@ Enable Prometheus with custom `values.yaml`
     repository = "https://prometheus-community.github.io/helm-charts" # (Optional) Repository URL where to locate the requested chart.
     chart      = "prometheus"                                         # (Required) Chart name to be installed.
     version    = "15.3.0"                                             # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config: https://github.com/aws-samples/aws-eks-accelerator-for-terraform/blob/main/modules/kubernetes-addons/prometheus/locals.tf
-    namespace  = "prometheus"                                         # (Optional) The namespace to install the release into. Defaults to default
+    namespace  = "prometheus"                                         # (Optional) The namespace to install the release into.
     values = [templatefile("${path.module}/prometheus-values.yaml", {
       operating_system = "linux"
     })]

--- a/docs/add-ons/vpa.md
+++ b/docs/add-ons/vpa.md
@@ -21,7 +21,7 @@ Alternatively, you can override the helm values by using the code snippet below
     repository = "https://charts.fairwinds.com/stable" # (Optional) Repository URL where to locate the requested chart.
     chart      = "vpa"                                 # (Required) Chart name to be installed.
     version    = "1.0.0"                               # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config: https://github.com/aws-samples/aws-eks-accelerator-for-terraform/blob/main/modules/kubernetes-addons/vpa/locals.tf
-    namespace  = "vpa-ns"                              # (Optional) The namespace to install the release into. Defaults to default
+    namespace  = "vpa-ns"                              # (Optional) The namespace to install the release into.
     values     = [templatefile("${path.module}/values.yaml", {})]
   }
 ```

--- a/docs/add-ons/vpa.md
+++ b/docs/add-ons/vpa.md
@@ -21,7 +21,7 @@ Alternatively, you can override the helm values by using the code snippet below
     repository = "https://charts.fairwinds.com/stable" # (Optional) Repository URL where to locate the requested chart.
     chart      = "vpa"                                 # (Required) Chart name to be installed.
     version    = "1.0.0"                               # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config: https://github.com/aws-samples/aws-eks-accelerator-for-terraform/blob/main/modules/kubernetes-addons/vpa/locals.tf
-    namespace  = "vpa-ns"                              # (Optional) The namespace to install the release into.
+    namespace  = "vpa"                              # (Optional) The namespace to install the release into.
     values     = [templatefile("${path.module}/values.yaml", {})]
   }
 ```

--- a/examples/advanced/k8s_addons/main.tf
+++ b/examples/advanced/k8s_addons/main.tf
@@ -451,7 +451,7 @@ module "kubernetes-addons" {
     name       = "keda"                              # (Required) Release name.
     repository = "https://kedacore.github.io/charts" # (Optional) Repository URL where to locate the requested chart.
     chart      = "keda"                              # (Required) Chart name to be installed.
-    version    = "2.4.0"                             # (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
+    version    = "2.6.2"                             # (Optional) Specify the exact chart version to install.
     namespace  = "keda"                              # (Optional) The namespace to install the release into. Defaults to default
     values     = [templatefile("${path.module}/helm_values/keda-values.yaml", {})]
   }
@@ -463,7 +463,7 @@ module "kubernetes-addons" {
     name       = "vpa"                                 # (Required) Release name.
     repository = "https://charts.fairwinds.com/stable" # (Optional) Repository URL where to locate the requested chart.
     chart      = "vpa"                                 # (Required) Chart name to be installed.
-    version    = "1.0.0"                               # (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
+    version    = "1.0.0"                               # (Optional) Specify the exact chart version to install.
     namespace  = "vpa-ns"                              # (Optional) The namespace to install the release into. Defaults to default
     values     = [templatefile("${path.module}/helm_values/vpa-values.yaml", {})]
   }

--- a/examples/advanced/k8s_addons/main.tf
+++ b/examples/advanced/k8s_addons/main.tf
@@ -464,7 +464,7 @@ module "kubernetes-addons" {
     repository = "https://charts.fairwinds.com/stable" # (Optional) Repository URL where to locate the requested chart.
     chart      = "vpa"                                 # (Required) Chart name to be installed.
     version    = "1.0.0"                               # (Optional) Specify the exact chart version to install.
-    namespace  = "vpa-ns"                              # (Optional) The namespace to install the release into.
+    namespace  = "vpa"                                 # (Optional) The namespace to install the release into.
     values     = [templatefile("${path.module}/helm_values/vpa-values.yaml", {})]
   }
   #---------------------------------------

--- a/examples/advanced/k8s_addons/main.tf
+++ b/examples/advanced/k8s_addons/main.tf
@@ -237,8 +237,8 @@ module "kubernetes-addons" {
     name       = "traefik"                         # (Required) Release name.
     repository = "https://helm.traefik.io/traefik" # (Optional) Repository URL where to locate the requested chart.
     chart      = "traefik"                         # (Required) Chart name to be installed.
-    version    = "10.0.0"                          # (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
-    namespace  = "kube-system"                     # (Optional) The namespace to install the release into. Defaults to default
+    version    = "10.0.0"                          # (Optional) Specify the exact chart version to install.
+    namespace  = "kube-system"                     # (Optional) The namespace to install the release into.
     timeout    = "1200"                            # (Optional)
     lint       = "true"                            # (Optional)
     # (Optional) Example to show how to override values using SET
@@ -260,8 +260,8 @@ module "kubernetes-addons" {
     name       = "metrics-server"                                    # (Required) Release name.
     repository = "https://kubernetes-sigs.github.io/metrics-server/" # (Optional) Repository URL where to locate the requested chart.
     chart      = "metrics-server"                                    # (Required) Chart name to be installed.
-    version    = "3.8.1"                                             # (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
-    namespace  = "kube-system"                                       # (Optional) The namespace to install the release into. Defaults to default
+    version    = "3.8.1"                                             # (Optional) Specify the exact chart version to install.
+    namespace  = "kube-system"                                       # (Optional) The namespace to install the release into.
     timeout    = "1200"                                              # (Optional)
     lint       = "true"                                              # (Optional)
     # (Optional) Example to show how to pass metrics-server-values.yaml
@@ -278,8 +278,8 @@ module "kubernetes-addons" {
     name       = "cluster-autoscaler"                      # (Required) Release name.
     repository = "https://kubernetes.github.io/autoscaler" # (Optional) Repository URL where to locate the requested chart.
     chart      = "cluster-autoscaler"                      # (Required) Chart name to be installed.
-    version    = "9.10.7"                                  # (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
-    namespace  = "kube-system"                             # (Optional) The namespace to install the release into. Defaults to default
+    version    = "9.10.7"                                  # (Optional) Specify the exact chart version to install.
+    namespace  = "kube-system"                             # (Optional) The namespace to install the release into.
     timeout    = "1200"                                    # (Optional)
     lint       = "true"                                    # (Optional)
     # (Optional) Example to show how to pass metrics-server-values.yaml
@@ -300,8 +300,8 @@ module "kubernetes-addons" {
     name       = "prometheus"                                         # (Required) Release name.
     repository = "https://prometheus-community.github.io/helm-charts" # (Optional) Repository URL where to locate the requested chart.
     chart      = "prometheus"                                         # (Required) Chart name to be installed.
-    version    = "15.3.0"                                             # (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
-    namespace  = "prometheus"                                         # (Optional) The namespace to install the release into. Defaults to default
+    version    = "15.3.0"                                             # (Optional) Specify the exact chart version to install.
+    namespace  = "prometheus"                                         # (Optional) The namespace to install the release into.
     values = [templatefile("${path.module}/helm_values/prometheus-values.yaml", {
       operating_system = "linux"
     })]
@@ -452,7 +452,7 @@ module "kubernetes-addons" {
     repository = "https://kedacore.github.io/charts" # (Optional) Repository URL where to locate the requested chart.
     chart      = "keda"                              # (Required) Chart name to be installed.
     version    = "2.6.2"                             # (Optional) Specify the exact chart version to install.
-    namespace  = "keda"                              # (Optional) The namespace to install the release into. Defaults to default
+    namespace  = "keda"                              # (Optional) The namespace to install the release into.
     values     = [templatefile("${path.module}/helm_values/keda-values.yaml", {})]
   }
   #---------------------------------------
@@ -464,7 +464,7 @@ module "kubernetes-addons" {
     repository = "https://charts.fairwinds.com/stable" # (Optional) Repository URL where to locate the requested chart.
     chart      = "vpa"                                 # (Required) Chart name to be installed.
     version    = "1.0.0"                               # (Optional) Specify the exact chart version to install.
-    namespace  = "vpa-ns"                              # (Optional) The namespace to install the release into. Defaults to default
+    namespace  = "vpa-ns"                              # (Optional) The namespace to install the release into.
     values     = [templatefile("${path.module}/helm_values/vpa-values.yaml", {})]
   }
   #---------------------------------------
@@ -475,7 +475,7 @@ module "kubernetes-addons" {
     name       = "yunikorn"                                            # (Required) Release name.
     repository = "https://apache.github.io/incubator-yunikorn-release" # (Optional) Repository URL where to locate the requested chart.
     chart      = "yunikorn"                                            # (Required) Chart name to be installed.
-    version    = "0.12.2"                                              # (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
+    version    = "0.12.2"                                              # (Optional) Specify the exact chart version to install.
     values     = [templatefile("${path.module}/helm_values/yunikorn-values.yaml", {})]
   }
 

--- a/examples/analytics/emr-on-eks/examples/EMR-EKS-AMP-AMG-BLOG.md
+++ b/examples/analytics/emr-on-eks/examples/EMR-EKS-AMP-AMG-BLOG.md
@@ -55,7 +55,7 @@ Let’s verify the resources
 
 * Login to AWS console and verify the VPC, three Private Subnets and three Public Subnets, Internet gateway and single NAT Gateway created with the prefix of aws001-prerpod-test-
 * Open the EKS service page from the AWS console to verify the EKS cluster(aws001-preprod-test-eks) with one Managed node group with an instance type of m5.xlarge.
-* Also, select the workloads dropdown under the workloads tab in EKS cluster page to verify the Prometheus Server pods under prometheus namespace, EMR on EKS Namespaces emr-data-team-a and emr-data-team-b, Vertical Pod Autoscaler pods under vpa-ns and Metrics Server & Cluster Autoscaler under kube-system namespace
+* Also, select the workloads dropdown under the workloads tab in EKS cluster page to verify the Prometheus Server pods under prometheus namespace, EMR on EKS Namespaces `emr-data-team-a` and `emr-data-team-b`, Vertical Pod Autoscaler pods under the `vpa` namespace and Metrics Server & Cluster Autoscaler under `kube-system` namespace
 * This deployment also creates a new Amazon Managed Prometheus workspace and configures community Prometheus Server add-on to *remote write metrics*.
 
 ### Step4: Create EMR Virtual Cluster

--- a/examples/analytics/emr-on-eks/main.tf
+++ b/examples/analytics/emr-on-eks/main.tf
@@ -168,8 +168,8 @@ module "kubernetes-addons" {
     name       = "prometheus"                                         # (Required) Release name.
     repository = "https://prometheus-community.github.io/helm-charts" # (Optional) Repository URL where to locate the requested chart.
     chart      = "prometheus"                                         # (Required) Chart name to be installed.
-    version    = "15.3.0"                                             # (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
-    namespace  = "prometheus"                                         # (Optional) The namespace to install the release into. Defaults to default
+    version    = "15.3.0"                                             # (Optional) Specify the exact chart version to install.
+    namespace  = "prometheus"                                         # (Optional) The namespace to install the release into.
     values = [templatefile("${path.module}/helm_values/prometheus-values.yaml", {
       operating_system = "linux"
     })]
@@ -183,8 +183,8 @@ module "kubernetes-addons" {
     name       = "vpa"                                 # (Required) Release name.
     repository = "https://charts.fairwinds.com/stable" # (Optional) Repository URL where to locate the requested chart.
     chart      = "vpa"                                 # (Required) Chart name to be installed.
-    version    = "1.0.0"                               # (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
-    namespace  = "vpa-ns"                              # (Optional) The namespace to install the release into. Defaults to default
+    version    = "1.0.0"                               # (Optional) Specify the exact chart version to install
+    namespace  = "vpa-ns"                              # (Optional) The namespace to install the release into.
     values     = [templatefile("${path.module}/helm_values/vpa-values.yaml", {})]
   }
 

--- a/examples/analytics/emr-on-eks/main.tf
+++ b/examples/analytics/emr-on-eks/main.tf
@@ -184,7 +184,7 @@ module "kubernetes-addons" {
     repository = "https://charts.fairwinds.com/stable" # (Optional) Repository URL where to locate the requested chart.
     chart      = "vpa"                                 # (Required) Chart name to be installed.
     version    = "1.0.0"                               # (Optional) Specify the exact chart version to install
-    namespace  = "vpa-ns"                              # (Optional) The namespace to install the release into.
+    namespace  = "vpa"                                 # (Optional) The namespace to install the release into.
     values     = [templatefile("${path.module}/helm_values/vpa-values.yaml", {})]
   }
 

--- a/examples/analytics/spark-k8s-operator/main.tf
+++ b/examples/analytics/spark-k8s-operator/main.tf
@@ -133,8 +133,8 @@ module "kubernetes-addons" {
     name       = "prometheus"                                         # (Required) Release name.
     repository = "https://prometheus-community.github.io/helm-charts" # (Optional) Repository URL where to locate the requested chart.
     chart      = "prometheus"                                         # (Required) Chart name to be installed.
-    version    = "15.3.0"                                             # (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
-    namespace  = "prometheus"                                         # (Optional) The namespace to install the release into. Defaults to default
+    version    = "15.3.0"                                             # (Optional) Specify the exact chart version to install.
+    namespace  = "prometheus"                                         # (Optional) The namespace to install the release into.
     values = [templatefile("${path.module}/helm_values/prometheus-values.yaml", {
       operating_system = "linux"
     })]
@@ -162,7 +162,7 @@ module "kubernetes-addons" {
     name       = "yunikorn"                                            # (Required) Release name.
     repository = "https://apache.github.io/incubator-yunikorn-release" # (Optional) Repository URL where to locate the requested chart.
     chart      = "yunikorn"                                            # (Required) Chart name to be installed.
-    version    = "0.12.2"                                              # (Optional) Specify the exact chart version to install. If this is not specified, the latest version is installed.
+    version    = "0.12.2"                                              # (Optional) Specify the exact chart version to install.
     values     = [templatefile("${path.module}/helm_values/yunikorn-values.yaml", {})]
   }
 

--- a/modules/kubernetes-addons/keda/locals.tf
+++ b/modules/kubernetes-addons/keda/locals.tf
@@ -33,7 +33,7 @@ locals {
     name                       = "keda"
     chart                      = "keda"
     repository                 = "https://kedacore.github.io/charts"
-    version                    = "2.4.0"
+    version                    = "2.6.2"
     namespace                  = "keda"
     timeout                    = "1200"
     create_namespace           = false

--- a/modules/kubernetes-addons/vpa/locals.tf
+++ b/modules/kubernetes-addons/vpa/locals.tf
@@ -18,14 +18,14 @@
 
 locals {
   service_account_name = "vpa-sa"
-  namespace            = "vpa-ns"
+  namespace            = "vpa"
 
   default_helm_config = {
     name                       = "vpa"
     chart                      = "vpa"
     repository                 = "https://charts.fairwinds.com/stable"
     version                    = "1.0.0"
-    namespace                  = "vpa-ns"
+    namespace                  = "vpa"
     timeout                    = "1200"
     create_namespace           = true
     description                = "Kubernetes Vertical Pod Autoscaler"


### PR DESCRIPTION
### What does this PR do?

Updates the helm chart for keda to 2.6.2 and updates keda helm chart version references in examples and documentation. 

This also removes some old comments that don't apply - references to default versions and namespaces that are no longer true.


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [x] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
  - https://github.com/aws-samples/ssp-eks-add-ons/pull/16
- [x] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes
Test notes:
  - created test directory and filled main.tf file with vpc, eks cluster with metrics server addon enabled
  - ran `terraform apply -auto-approve` and checked that deployment completes
  - ran `kubectl logs -n keda-ns <pod>` to check logs for errors for both pods

