### PR TITLE
Updated Windows example and docs

### DIFF
--- a/docs/node-groups.md
+++ b/docs/node-groups.md
@@ -166,3 +166,36 @@ The example below demonstrates how you can customize a Fargate profile for your 
       }
     }
 ```
+
+### Windows Self-Managed Node Groups
+
+The example below demonstrates the minimum configuration required to deploy a Self-managed node group of Windows nodes. Refer to the [AWS EKS user guide](https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html) for more information about Windows support in EKS.
+
+```hcl
+  # SELF-MANAGED NODE GROUP with Windows support
+  enable_windows_support = true
+
+  self_managed_node_groups = {
+    ng_od_windows = {
+      node_group_name    = "ng-od-windows"
+      launch_template_os = "windows"
+      instance_type      = "m5n.large"
+      subnet_ids         = module.aws_vpc.private_subnets
+      min_size           = "2"
+    }
+  }
+```
+
+In clusters where Windows support is enabled, workloads shold have explicit node assignments configured using `nodeSelector` or `affinity`, as described in the Kubernetes document [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). For example, if you are enabling the `metrics-server` Kubernetes add-on (Helm chart), use the following configuration to ensure its pods are assigned to Linux nodes. See the [EKS Cluster with Windows Support example](../examples/eks-cluster-with-windows-support/) for full Terraform configuration and workload deployment samples.
+
+```hcl
+  enable_metrics_server = true
+  metrics_server_helm_config = {
+    set = [
+      {
+        name  = "nodeSelector.kubernetes\\.io/os"
+        value = "linux"
+      }
+    ]
+  }
+```

--- a/docs/node-groups.md
+++ b/docs/node-groups.md
@@ -186,7 +186,7 @@ The example below demonstrates the minimum configuration required to deploy a Se
   }
 ```
 
-In clusters where Windows support is enabled, workloads shold have explicit node assignments configured using `nodeSelector` or `affinity`, as described in the Kubernetes document [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). For example, if you are enabling the `metrics-server` Kubernetes add-on (Helm chart), use the following configuration to ensure its pods are assigned to Linux nodes. See the [EKS Cluster with Windows Support example](../examples/eks-cluster-with-windows-support/) for full Terraform configuration and workload deployment samples.
+In clusters where Windows support is enabled, workloads should have explicit node assignments configured using `nodeSelector` or `affinity`, as described in the Kubernetes document [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). For example, if you are enabling the `metrics-server` Kubernetes add-on (Helm chart), use the following configuration to ensure its pods are assigned to Linux nodes. See the [EKS Cluster with Windows Support example](../examples/eks-cluster-with-windows-support/) for full Terraform configuration and workload deployment samples.
 
 ```hcl
   enable_metrics_server = true

--- a/examples/eks-cluster-with-windows-support/README.md
+++ b/examples/eks-cluster-with-windows-support/README.md
@@ -32,9 +32,11 @@ terraform init
 to verify the resources created by this execution
 
 ```bash
-export AWS_REGION=<enter-your-region>   # Select your own region
+export AWS_REGION=us-east-1   # Select your own region
 terraform plan
 ```
+
+If you want to use a region other than `us-east-1`, update the `aws_region` name and `aws_availability_zones` filter in the data sources in [main.tf](./main.tf) accordingly.
 
 ### Step4: Run `terraform apply`
 to create resources
@@ -48,30 +50,35 @@ EKS Cluster details can be extracted from terraform output or from AWS Console t
 
 ### Step5: Run `update-kubeconfig` command.
 
-`~/.kube/config` file gets updated with EKS cluster context from the below command. Use the cluster's name available in the Terraform output as `eks_cluster_name`.
+`~/.kube/config` file gets updated with EKS cluster context from the below command. Replace the region name and EKS cluster name with your cluster's name. (If you did not change the `tenant`, `environment`, and `zone` values in this example, the EKS cluster name will be `aws001-preprod-dev-eks`.)
 
-    $ aws eks --region <enter-your-region> update-kubeconfig --name <eks_cluster_name>
+    $ aws eks --region us-east-1 update-kubeconfig --name aws001-preprod-dev-eks
 
 ### Step6: (Optional) Deploy sample Windows and Linux workloads to verify support for both operating systems
-When Windows support is enabled in the cluster, it is necessary to use one of the ways to assign pods to specific nodes, such as `nodeSelector` or `affinity`.
-See the [K8s documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) for more info.
-This example uses `nodeSelector`s to select nodes with appropriate OS for pods.
+When Windows support is enabled in the cluster, it is necessary to use one of the ways to assign pods to specific nodes, such as `nodeSelector` or `affinity`. See the [K8s documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) for more info. This example uses `nodeSelector`s to select nodes with appropriate OS for pods.
 
 #### Sample Windows deployment
 ```bash
 cd examples/eks-cluster-with-windows-support
 
 # Sample Windows deployment
-  kubectl apply -f ./k8s/windows-iis-aspnet.yaml
+kubectl apply -f ./k8s/windows-iis-aspnet.yaml
 
 # Wait for the Windows pod status to change to Running
+# The following command will work on Linux
 # On Mac, install the watch command using brew install watch
-  watch -n 1 "kubectl get po -n windows"
+watch -n 1 "kubectl get po -n windows"
 
-# When the pod starts running, forward the service port
-  kubectl port-forward -n windows service/aspnet 8000:80
+# When the pod starts running, create a proxy to the K8s API
+kubectl proxy
 ```
-Now visit [http://localhost:8000/demo](http://localhost:8000/demo) in your browser. If everything went well, the page should display text "Hello, World!". Use Ctrl+C in your terminal to stop the `kubectl` port forwarding.
+Now visit [http://127.0.0.1:8001/api/v1/namespaces/windows/services/aspnet/proxy/demo](http://127.0.0.1:8001/api/v1/namespaces/windows/services/aspnet/proxy/demo) in your browser. If everything went well, the page should display text "Hello, World!". Use Ctrl+C in your terminal to stop the `kubectl` proxy.
+
+Note: The `aspnet` service created by above example is a `LoadBalancer` service, so you can also visit the Network Load Balancer (NLB) endpoint in your browser instead of using `kubectl proxy` as mentioned above. To be able to access the NLB endpoint, update the security group attached to the Windows node where the `aspnet` pod is running to allow inbound access to port 80 from your IP address. You can grab the NLB endpoint from the service using the following command:
+
+```
+kubectl get svc -n windows -o jsonpath="{.items[0].status.loadBalancer.ingress[0].hostname}"
+```
 
 #### Sample Linux deployment
 ```bash

--- a/examples/eks-cluster-with-windows-support/k8s/windows-iis-aspnet.yaml
+++ b/examples/eks-cluster-with-windows-support/k8s/windows-iis-aspnet.yaml
@@ -41,6 +41,11 @@ kind: Service
 metadata:
   name: aspnet
   namespace: windows
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+    service.beta.kubernetes.io/aws-load-balancer-type: "external"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
 spec:
   ports:
   - port: 80
@@ -49,4 +54,4 @@ spec:
   selector:
     app: aspnet
   sessionAffinity: None
-  type: ClusterIP
+  type: LoadBalancer

--- a/examples/eks-cluster-with-windows-support/main.tf
+++ b/examples/eks-cluster-with-windows-support/main.tf
@@ -21,9 +21,21 @@ terraform {
   }
 }
 
-data "aws_region" "current" {}
+data "aws_region" "current" {
+  # Change this per your need
+  name = "us-east-1"
+}
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  state = "available"
+  # Specify AZs to avoid EKS cluster creation error due to reduced capacity in an AZ.
+  # Change the AZ names per capacity available in the region you selected.
+  # https://aws.amazon.com/premiumsupport/knowledge-center/eks-cluster-creation-errors/
+  filter {
+    name   = "zone-name"
+    values = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  }
+}
 
 data "aws_eks_cluster" "cluster" {
   name = module.aws-eks-accelerator-for-terraform.eks_cluster_id
@@ -100,7 +112,7 @@ module "aws_vpc" {
 # Example to consume aws-eks-accelerator-for-terraform module
 #---------------------------------------------------------------
 module "aws-eks-accelerator-for-terraform" {
-  source = "../.."
+  source = "git@github.com:aws-samples/aws-eks-accelerator-for-terraform.git?ref=v3.2.1"
 
   tenant            = local.tenant
   environment       = local.environment
@@ -143,7 +155,7 @@ module "aws-eks-accelerator-for-terraform" {
 }
 
 module "kubernetes-addons" {
-  source = "../../modules/kubernetes-addons"
+  source = "git@github.com:aws-samples/aws-eks-accelerator-for-terraform.git//modules/kubernetes-addons?ref=v3.2.1"
 
   eks_cluster_id = module.aws-eks-accelerator-for-terraform.eks_cluster_id
 
@@ -152,10 +164,37 @@ module "kubernetes-addons" {
   enable_amazon_eks_coredns    = true
   enable_amazon_eks_kube_proxy = true
 
-  #K8s Add-ons
+  # K8s Add-ons
+  # Ensure proper node assignment
   enable_aws_load_balancer_controller = true
-  enable_metrics_server               = true
-  enable_cluster_autoscaler           = true
+  aws_load_balancer_controller_helm_config = {
+    set = [
+      {
+        name  = "nodeSelector.kubernetes\\.io/os"
+        value = "linux"
+      }
+    ]
+  }
+
+  enable_metrics_server = true
+  metrics_server_helm_config = {
+    set = [
+      {
+        name  = "nodeSelector.kubernetes\\.io/os"
+        value = "linux"
+      }
+    ]
+  }
+
+  enable_cluster_autoscaler = true
+  cluster_autoscaler_helm_config = {
+    set = [
+      {
+        name  = "nodeSelector.kubernetes\\.io/os"
+        value = "linux"
+      }
+    ]
+  }
 
   depends_on = [module.aws-eks-accelerator-for-terraform.managed_node_groups]
 }


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This updates ensures the Windows support example will continue to work regardless of new changes merged into the SSP repo. Also includes code improvements to ensure proper workload node assignment and avoiding EKS cluster creation error in case of reduced capacity in specific AZs, and README, and docs improvements.

### Motivation

<!-- What inspired you to submit this pull request? -->
As Windows support example is typically not tested by multiple code contributors and approvers, it has got broken multiple times in the past, including the recent changes. This update will pin the version of the SSP module that is known to work, avoid impact of new bugs, and allow sufficient time to upgrade the example for new changes.

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
