### PR TITLE
Self managed node groups launch template fix

### DIFF
--- a/modules/aws-eks-managed-node-groups/locals.tf
+++ b/modules/aws-eks-managed-node-groups/locals.tf
@@ -8,7 +8,7 @@ locals {
     custom_ami_id   = ""
     subnet_type     = "private"
     subnet_ids      = []
-    release_version = "latest"
+    release_version = ""
 
     desired_size    = "3"
     max_size        = "3"

--- a/modules/aws-eks-managed-node-groups/locals.tf
+++ b/modules/aws-eks-managed-node-groups/locals.tf
@@ -6,7 +6,9 @@ locals {
     capacity_type   = "ON_DEMAND"  # ON_DEMAND, SPOT
     ami_type        = "AL2_x86_64" # AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64, BOTTLEROCKET_x86_64, BOTTLEROCKET_ARM_64
     custom_ami_id   = ""
+    subnet_type     = "private"
     subnet_ids      = []
+    release_version = "latest"
 
     desired_size    = "3"
     max_size        = "3"
@@ -24,8 +26,7 @@ locals {
     k8s_taints      = []
     additional_tags = {}
 
-    create_worker_security_group         = false
-    worker_additional_security_group_ids = [] # Will use this when create_worker_security_group = true
+    create_worker_security_group = false
 
     # LAUNCH TEMPLATES
     create_launch_template  = false

--- a/modules/aws-eks-managed-node-groups/main.tf
+++ b/modules/aws-eks-managed-node-groups/main.tf
@@ -2,7 +2,8 @@ resource "aws_eks_node_group" "managed_ng" {
   cluster_name           = var.eks_cluster_id
   node_group_name_prefix = local.managed_node_group["node_group_name"]
   node_role_arn          = aws_iam_role.managed_ng.arn
-  subnet_ids             = local.managed_node_group["subnet_ids"]
+  subnet_ids             = length(local.managed_node_group["subnet_ids"]) == 0 ? (local.managed_node_group["subnet_type"] == "private" ? var.private_subnet_ids : var.public_subnet_ids) : local.managed_node_group["subnet_ids"]
+  release_version        = local.managed_node_group["release_version"]
 
   ami_type       = local.managed_node_group["ami_type"] != "" ? local.managed_node_group["ami_type"] : null
   capacity_type  = local.managed_node_group["capacity_type"]

--- a/modules/aws-eks-managed-node-groups/main.tf
+++ b/modules/aws-eks-managed-node-groups/main.tf
@@ -3,7 +3,7 @@ resource "aws_eks_node_group" "managed_ng" {
   node_group_name_prefix = local.managed_node_group["node_group_name"]
   node_role_arn          = aws_iam_role.managed_ng.arn
   subnet_ids             = length(local.managed_node_group["subnet_ids"]) == 0 ? (local.managed_node_group["subnet_type"] == "public" ? var.public_subnet_ids : var.private_subnet_ids) : local.managed_node_group["subnet_ids"]
-  release_version        = local.managed_node_group["release_version"]
+  release_version        = try(local.managed_node_group["release_version"], "") == "" ? null : local.managed_node_group["release_version"]
 
   ami_type       = local.managed_node_group["ami_type"] != "" ? local.managed_node_group["ami_type"] : null
   capacity_type  = local.managed_node_group["capacity_type"]

--- a/modules/aws-eks-managed-node-groups/main.tf
+++ b/modules/aws-eks-managed-node-groups/main.tf
@@ -2,7 +2,7 @@ resource "aws_eks_node_group" "managed_ng" {
   cluster_name           = var.eks_cluster_id
   node_group_name_prefix = local.managed_node_group["node_group_name"]
   node_role_arn          = aws_iam_role.managed_ng.arn
-  subnet_ids             = length(local.managed_node_group["subnet_ids"]) == 0 ? (local.managed_node_group["subnet_type"] == "private" ? var.private_subnet_ids : var.public_subnet_ids) : local.managed_node_group["subnet_ids"]
+  subnet_ids             = length(local.managed_node_group["subnet_ids"]) == 0 ? (local.managed_node_group["subnet_type"] == "public" ? var.public_subnet_ids : var.private_subnet_ids) : local.managed_node_group["subnet_ids"]
   release_version        = local.managed_node_group["release_version"]
 
   ami_type       = local.managed_node_group["ami_type"] != "" ? local.managed_node_group["ami_type"] : null

--- a/modules/aws-eks-managed-node-groups/managed-launch-templates.tf
+++ b/modules/aws-eks-managed-node-groups/managed-launch-templates.tf
@@ -40,7 +40,7 @@ resource "aws_launch_template" "managed_node_groups" {
 
   network_interfaces {
     associate_public_ip_address = local.managed_node_group["public_ip"]
-    security_groups             = local.managed_node_group["create_worker_security_group"] == true ? compact(flatten([[aws_security_group.managed_ng[0].id], local.managed_node_group["worker_additional_security_group_ids"]])) : compact(flatten([[var.worker_security_group_id], var.worker_additional_security_group_ids]))
+    security_groups             = local.managed_node_group["create_worker_security_group"] == true ? compact(flatten([[aws_security_group.managed_ng[0].id], var.worker_additional_security_group_ids])) : compact(flatten([[var.worker_security_group_id], var.worker_additional_security_group_ids]))
   }
 
   lifecycle {

--- a/modules/aws-eks-self-managed-node-groups/locals.tf
+++ b/modules/aws-eks-self-managed-node-groups/locals.tf
@@ -25,13 +25,13 @@ locals {
     ]
 
     # AUTOSCALING
-    max_size                             = "3"
-    min_size                             = "1"
-    subnet_ids                           = []
-    additional_tags                      = {}
-    create_worker_security_group         = false
-    worker_additional_security_group_ids = [] # Will use this when create_worker_security_group = true
-    additional_iam_policies              = []
+    max_size                     = "3"
+    min_size                     = "1"
+    subnet_type                  = "private"
+    subnet_ids                   = []
+    additional_tags              = {}
+    create_worker_security_group = false
+    additional_iam_policies      = []
   }
 
   self_managed_node_group = merge(

--- a/modules/aws-eks-self-managed-node-groups/main.tf
+++ b/modules/aws-eks-self-managed-node-groups/main.tf
@@ -3,7 +3,7 @@ resource "aws_autoscaling_group" "self_managed_ng" {
 
   max_size            = local.self_managed_node_group["max_size"]
   min_size            = local.self_managed_node_group["min_size"]
-  vpc_zone_identifier = length(local.self_managed_node_group["subnet_ids"]) == 0 ? (local.self_managed_node_group["subnet_type"] == "private" ? var.private_subnet_ids : var.public_subnet_ids) : local.self_managed_node_group["subnet_ids"]
+  vpc_zone_identifier = length(local.self_managed_node_group["subnet_ids"]) == 0 ? (local.self_managed_node_group["subnet_type"] == "public" ? var.public_subnet_ids : var.private_subnet_ids) : local.self_managed_node_group["subnet_ids"]
 
   launch_template {
     id      = module.launch_template_self_managed_ng.launch_template_id[local.lt_self_managed_group_map_key]

--- a/modules/aws-eks-self-managed-node-groups/main.tf
+++ b/modules/aws-eks-self-managed-node-groups/main.tf
@@ -3,7 +3,7 @@ resource "aws_autoscaling_group" "self_managed_ng" {
 
   max_size            = local.self_managed_node_group["max_size"]
   min_size            = local.self_managed_node_group["min_size"]
-  vpc_zone_identifier = local.self_managed_node_group["subnet_ids"]
+  vpc_zone_identifier = length(local.self_managed_node_group["subnet_ids"]) == 0 ? (local.self_managed_node_group["subnet_type"] == "private" ? var.private_subnet_ids : var.public_subnet_ids) : local.self_managed_node_group["subnet_ids"]
 
   launch_template {
     id      = module.launch_template_self_managed_ng.launch_template_id[local.lt_self_managed_group_map_key]

--- a/modules/aws-eks-self-managed-node-groups/self-managed-launch-templates.tf
+++ b/modules/aws-eks-self-managed-node-groups/self-managed-launch-templates.tf
@@ -9,7 +9,14 @@ module "launch_template_self_managed_ng" {
       launch_template_prefix = local.self_managed_node_group["node_group_name"]
       instance_type          = local.self_managed_node_group["instance_type"]
       capacity_type          = local.self_managed_node_group["capacity_type"]
-      iam_instance_profile   = aws_iam_instance_profile.self_managed_ng.name
+
+      pre_userdata         = local.self_managed_node_group["pre_userdata"]
+      bootstrap_extra_args = local.self_managed_node_group["bootstrap_extra_args"]
+      post_userdata        = local.self_managed_node_group["post_userdata"]
+      kubelet_extra_args   = local.self_managed_node_group["kubelet_extra_args"]
+      monitoring           = local.self_managed_node_group["enable_monitoring"]
+
+      iam_instance_profile = aws_iam_instance_profile.self_managed_ng.name
 
       block_device_mappings = local.self_managed_node_group["block_device_mappings"]
 
@@ -17,11 +24,9 @@ module "launch_template_self_managed_ng" {
         {
           public_ip = local.self_managed_node_group["public_ip"]
           security_groups = (
-            local.self_managed_node_group["create_worker_security_group"] == true ? compact(
-              flatten([[aws_security_group.self_managed_ng[0].id],
-              local.self_managed_node_group["worker_additional_security_group_ids"]])) : compact(
-              flatten([[var.worker_security_group_id],
-          var.worker_additional_security_group_ids])))
+            local.self_managed_node_group["create_worker_security_group"] == true
+            ? compact(flatten([[aws_security_group.self_managed_ng[0].id], var.worker_additional_security_group_ids]))
+          : compact(flatten([[var.worker_security_group_id], var.worker_additional_security_group_ids])))
         }
       ]
     }


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Fix for Self managed node groups launch templates #270
- Default subnets for node groups to be used in TFVARS #250 
- release version for managed node groups #275 

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
