### PR TITLE
change create eks default

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 | <a name="input_cluster_log_retention_in_days"></a> [cluster\_log\_retention\_in\_days](#input\_cluster\_log\_retention\_in\_days) | Number of days to retain log events. Default retention - 90 days. | `number` | `90` | no |
 | <a name="input_cluster_log_retention_period"></a> [cluster\_log\_retention\_period](#input\_cluster\_log\_retention\_period) | Number of days to retain cluster logs | `number` | `7` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | EKS Cluster Name | `string` | `""` | no |
-| <a name="input_create_eks"></a> [create\_eks](#input\_create\_eks) | Create EKS cluster | `bool` | `false` | no |
+| <a name="input_create_eks"></a> [create\_eks](#input\_create\_eks) | Create EKS cluster | `bool` | `true` | no |
 | <a name="input_emr_on_eks_teams"></a> [emr\_on\_eks\_teams](#input\_emr\_on\_eks\_teams) | EMR on EKS Teams config | `any` | `{}` | no |
 | <a name="input_enable_amazon_prometheus"></a> [enable\_amazon\_prometheus](#input\_enable\_amazon\_prometheus) | Enable AWS Managed Prometheus service | `bool` | `false` | no |
 | <a name="input_enable_emr_on_eks"></a> [enable\_emr\_on\_eks](#input\_enable\_emr\_on\_eks) | Enable EMR on EKS | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.73.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.66.0 |
 | <a name="provider_http"></a> [http](#provider\_http) | 2.4.1 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.7.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.7.1 |
 
 ## Modules
 
@@ -247,6 +247,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 | <a name="output_teams"></a> [teams](#output\_teams) | Outputs from EKS Fargate profiles groups |
 | <a name="output_windows_node_group_aws_auth_config_map"></a> [windows\_node\_group\_aws\_auth\_config\_map](#output\_windows\_node\_group\_aws\_auth\_config\_map) | Windows node groups AWS auth map |
 | <a name="output_worker_security_group_id"></a> [worker\_security\_group\_id](#output\_worker\_security\_group\_id) | EKS Worker Security group ID created by EKS module |
+
 <!--- END_TF_DOCS --->
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.66.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.73.0 |
 | <a name="provider_http"></a> [http](#provider\_http) | 2.4.1 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.7.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.7.1 |
 
 ## Modules
 
@@ -247,7 +247,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 | <a name="output_teams"></a> [teams](#output\_teams) | Outputs from EKS Fargate profiles groups |
 | <a name="output_windows_node_group_aws_auth_config_map"></a> [windows\_node\_group\_aws\_auth\_config\_map](#output\_windows\_node\_group\_aws\_auth\_config\_map) | Windows node groups AWS auth map |
 | <a name="output_worker_security_group_id"></a> [worker\_security\_group\_id](#output\_worker\_security\_group\_id) | EKS Worker Security group ID created by EKS module |
-
 <!--- END_TF_DOCS --->
 
 ## Security

--- a/examples/advanced/k8s_addons/main.tf
+++ b/examples/advanced/k8s_addons/main.tf
@@ -85,7 +85,6 @@ module "aws-eks-accelerator-for-terraform" {
   private_subnet_ids = local.private_subnet_ids
 
   # EKS CONTROL PLANE VARIABLES
-  create_eks         = true
   kubernetes_version = local.kubernetes_version
 
   # EKS MANAGED NODE GROUPS

--- a/examples/advanced/live/preprod/eu-west-1/application_acct/dev/main.tf
+++ b/examples/advanced/live/preprod/eu-west-1/application_acct/dev/main.tf
@@ -110,7 +110,6 @@ module "aws-eks-accelerator-for-terraform" {
   private_subnet_ids = module.aws_vpc.private_subnets
 
   # EKS CONTROL PLANE VARIABLES
-  create_eks         = true
   kubernetes_version = local.kubernetes_version
   #---------------------------------------------------------#
   # EKS WORKER NODE GROUPS

--- a/examples/analytics/emr-on-eks/main.tf
+++ b/examples/analytics/emr-on-eks/main.tf
@@ -99,8 +99,6 @@ module "aws_vpc" {
 module "aws-eks-accelerator-for-terraform" {
   source = "github.com/aws-samples/aws-eks-accelerator-for-terraform"
 
-  create_eks = true
-
   tenant            = local.tenant
   environment       = local.environment
   zone              = local.zone

--- a/examples/analytics/spark-k8s-operator/main.tf
+++ b/examples/analytics/spark-k8s-operator/main.tf
@@ -92,7 +92,6 @@ module "aws-eks-accelerator-for-terraform" {
   private_subnet_ids = module.aws_vpc.private_subnets
 
   # EKS CONTROL PLANE VARIABLES
-  create_eks         = true
   kubernetes_version = local.kubernetes_version
 
   # EKS MANAGED NODE GROUPS

--- a/examples/ci-cd/gitlab-ci-cd/main.tf
+++ b/examples/ci-cd/gitlab-ci-cd/main.tf
@@ -105,7 +105,6 @@ module "aws-eks-accelerator-for-terraform" {
   private_subnet_ids = module.aws_vpc.private_subnets
 
   # EKS CONTROL PLANE VARIABLES
-  create_eks         = true
   kubernetes_version = var.kubernetes_version
 
   # EKS MANAGED NODE GROUPS

--- a/examples/crossplane/main.tf
+++ b/examples/crossplane/main.tf
@@ -122,7 +122,6 @@ module "aws-eks-accelerator-for-terraform" {
   private_subnet_ids = module.aws_vpc.private_subnets
 
   # EKS CONTROL PLANE VARIABLES
-  create_eks         = true
   kubernetes_version = local.kubernetes_version
 
   # EKS MANAGED NODE GROUPS

--- a/examples/eks-cluster-with-argocd/main.tf
+++ b/examples/eks-cluster-with-argocd/main.tf
@@ -137,7 +137,6 @@ module "aws-eks-accelerator-for-terraform" {
   private_subnet_ids = module.aws_vpc.private_subnets
 
   # EKS CONTROL PLANE VARIABLES
-  create_eks         = true
   kubernetes_version = local.kubernetes_version
 
   # Managed Node Group

--- a/examples/eks-cluster-with-eks-addons/main.tf
+++ b/examples/eks-cluster-with-eks-addons/main.tf
@@ -111,7 +111,6 @@ module "aws-eks-accelerator-for-terraform" {
   private_subnet_ids = module.aws_vpc.private_subnets
 
   # EKS CONTROL PLANE VARIABLES
-  create_eks         = true
   kubernetes_version = local.kubernetes_version
 
   # EKS MANAGED NODE GROUPS

--- a/examples/eks-cluster-with-fargate-profiles/main.tf
+++ b/examples/eks-cluster-with-fargate-profiles/main.tf
@@ -102,7 +102,6 @@ module "aws-eks-accelerator-for-terraform" {
   private_subnet_ids = module.aws_vpc.private_subnets
 
   # EKS CONTROL PLANE VARIABLES
-  create_eks         = true
   kubernetes_version = local.kubernetes_version
   #---------------------------------------------------------#
   # FARGATE PROFILES

--- a/examples/eks-cluster-with-import-vpc/eks/main.tf
+++ b/examples/eks-cluster-with-import-vpc/eks/main.tf
@@ -65,7 +65,6 @@ module "aws-eks-accelerator-for-terraform" {
   private_subnet_ids = local.private_subnet_ids
 
   # EKS CONTROL PLANE VARIABLES
-  create_eks         = true
   kubernetes_version = local.kubernetes_version
 
   # EKS MANAGED NODE GROUPS

--- a/examples/eks-cluster-with-new-vpc/main.tf
+++ b/examples/eks-cluster-with-new-vpc/main.tf
@@ -110,7 +110,6 @@ module "aws-eks-accelerator-for-terraform" {
   private_subnet_ids = module.aws_vpc.private_subnets
 
   # EKS CONTROL PLANE VARIABLES
-  create_eks         = true
   kubernetes_version = local.kubernetes_version
 
   # EKS MANAGED NODE GROUPS

--- a/examples/eks-cluster-with-self-managed-node-groups/main.tf
+++ b/examples/eks-cluster-with-self-managed-node-groups/main.tf
@@ -102,7 +102,6 @@ module "aws-eks-accelerator-for-terraform" {
   private_subnet_ids = module.aws_vpc.private_subnets
 
   # EKS CONTROL PLANE VARIABLES
-  create_eks         = true
   kubernetes_version = local.kubernetes_version
 
   self_managed_node_groups = {

--- a/examples/eks-cluster-with-teams/main.tf
+++ b/examples/eks-cluster-with-teams/main.tf
@@ -124,7 +124,6 @@ module "aws-eks-accelerator-for-terraform" {
   private_subnet_ids = module.aws_vpc.private_subnets
 
   # EKS CONTROL PLANE VARIABLES
-  create_eks         = true
   kubernetes_version = local.kubernetes_version
 
   tags = {

--- a/examples/eks-cluster-with-windows-support/main.tf
+++ b/examples/eks-cluster-with-windows-support/main.tf
@@ -112,7 +112,6 @@ module "aws-eks-accelerator-for-terraform" {
   private_subnet_ids = module.aws_vpc.private_subnets
 
   # EKS CONTROL PLANE VARIABLES
-  create_eks         = true
   kubernetes_version = local.kubernetes_version
 
   # EKS MANAGED NODE GROUP

--- a/examples/eks-fully-private-eks-cluster/main.tf
+++ b/examples/eks-fully-private-eks-cluster/main.tf
@@ -196,7 +196,6 @@ module "aws-eks-accelerator-for-terraform" {
   private_subnet_ids = module.aws_vpc.private_subnets
 
   # EKS CONTROL PLANE VARIABLES
-  create_eks         = true
   kubernetes_version = local.kubernetes_version
 
   # Step 1. Set cluster API endpoint both private and public

--- a/examples/game-tech/agones-game-controller/main.tf
+++ b/examples/game-tech/agones-game-controller/main.tf
@@ -111,7 +111,6 @@ module "aws-eks-accelerator-for-terraform" {
   private_subnet_ids = module.aws_vpc.private_subnets
 
   # EKS CONTROL PLANE VARIABLES
-  create_eks         = true
   kubernetes_version = local.kubernetes_version
 
   # EKS MANAGED NODE GROUPS

--- a/examples/ingress-controllers/nginx/main.tf
+++ b/examples/ingress-controllers/nginx/main.tf
@@ -110,7 +110,6 @@ module "aws-eks-accelerator-for-terraform" {
   private_subnet_ids = module.aws_vpc.private_subnets
 
   # EKS CONTROL PLANE VARIABLES
-  create_eks         = true
   kubernetes_version = local.kubernetes_version
 
   # EKS MANAGED NODE GROUPS

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -125,7 +125,6 @@ module "aws-eks-accelerator-for-terraform" {
   private_subnet_ids = module.aws_vpc.private_subnets
 
   # EKS CONTROL PLANE VARIABLES
-  create_eks         = true
   kubernetes_version = local.kubernetes_version
 
   # Self-managed Node Group

--- a/examples/observability/eks-cluster-with-amp-amg-opensearch/main.tf
+++ b/examples/observability/eks-cluster-with-amp-amg-opensearch/main.tf
@@ -94,7 +94,6 @@ module "aws-eks-accelerator-for-terraform" {
   private_subnet_ids = module.aws_vpc.private_subnets
 
   # EKS Control Plane Variables
-  create_eks         = true
   kubernetes_version = local.kubernetes_version
 
   managed_node_groups = {

--- a/variables.tf
+++ b/variables.tf
@@ -73,7 +73,7 @@ variable "public_subnet_ids" {
 # EKS CONTROL PLANE
 variable "create_eks" {
   type        = bool
-  default     = false
+  default     = true
   description = "Create EKS cluster"
 }
 


### PR DESCRIPTION
### What does this PR do?

Sets `create_eks` to `true` by default and removes unnecessary use of the variable from examples.



### Motivation

Customers will need the control plane in most cases when using the framework. Very few customers are going to leverage an existing control plane. To that end the default behavior should be `create_eks = true` as is documented in our [README](./README.md).

### More

- [X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [N/A] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [N/A] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [X] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [X] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
