### PR TITLE
Remove hardcoded namespace values in argocd

### DIFF
--- a/examples/eks-cluster-with-windows-support/README.md
+++ b/examples/eks-cluster-with-windows-support/README.md
@@ -122,9 +122,9 @@ terraform destroy -auto-approve
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws-eks-accelerator-for-terraform"></a> [aws-eks-accelerator-for-terraform](#module\_aws-eks-accelerator-for-terraform) | ../.. | n/a |
+| <a name="module_aws-eks-accelerator-for-terraform"></a> [aws-eks-accelerator-for-terraform](#module\_aws-eks-accelerator-for-terraform) | git@github.com:aws-samples/aws-eks-accelerator-for-terraform.git | v3.2.1 |
 | <a name="module_aws_vpc"></a> [aws\_vpc](#module\_aws\_vpc) | terraform-aws-modules/vpc/aws | v3.2.0 |
-| <a name="module_kubernetes-addons"></a> [kubernetes-addons](#module\_kubernetes-addons) | ../../modules/kubernetes-addons | n/a |
+| <a name="module_kubernetes-addons"></a> [kubernetes-addons](#module\_kubernetes-addons) | git@github.com:aws-samples/aws-eks-accelerator-for-terraform.git//modules/kubernetes-addons | v3.2.1 |
 
 ## Resources
 

--- a/modules/kubernetes-addons/argocd/argocd-application/templates/application.yaml
+++ b/modules/kubernetes-addons/argocd/argocd-application/templates/application.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: {{ .Values.name }}
-  namespace: "argocd"
+  namespace: {{ .Values.namespace }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/modules/kubernetes-addons/argocd/main.tf
+++ b/modules/kubernetes-addons/argocd/main.tf
@@ -147,7 +147,7 @@ resource "kubernetes_secret" "argocd_gitops" {
 
   metadata {
     name      = "${each.key}-repo-secret"
-    namespace = "argocd"
+    namespace = local.helm_config["namespace"]
     labels    = { "argocd.argoproj.io/secret-type" : "repository" }
   }
 

--- a/modules/kubernetes-addons/argocd/main.tf
+++ b/modules/kubernetes-addons/argocd/main.tf
@@ -85,7 +85,7 @@ resource "helm_release" "argocd_application" {
   name      = each.key
   chart     = "${path.module}/argocd-application"
   version   = "1.0.0"
-  namespace = "argocd"
+  namespace = local.helm_config["namespace"]
 
   # Application Meta.
   set {


### PR DESCRIPTION
### What does this PR do?

Removes hardcoded namespace values in the argocd kubernetes addon module. Those entries now reference the argocd helm config.


### Motivation

Addressing: https://github.com/aws-samples/aws-eks-accelerator-for-terraform/issues/236

Thanks [sarasensible](https://github.com/sarasensible) for reporting this! 


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes
Testing notes:
  - created test directory and filled main.tf file with vpc, eks cluster with argocd addon enabled
  - ran `terraform apply -auto-approve` and checked that deployment completes
  - verified login page to argocd management console loaded with kubectl port-forwarding: `kubectl port-forward svc/argo-cd-argocd-server -n argocd 8080:443`
  - added non-default argocd namespace to kubernetes addon module and reapplied template
  ```
    argocd_helm_config = {
      namespace = "argocd-test"
    }
  ```
  - verified new namespace and that argocd login page loads with kubectl port-fowarding using new namespace
