### PR TITLE
Update k8s_taints documentation and taints fixes

### DIFF
--- a/docs/node-groups.md
+++ b/docs/node-groups.md
@@ -20,7 +20,7 @@ The below example demonstrates the minimum configuration required to deploy a ma
     }
 ```
 
-The below example demonstrates advanced configuration options for a manged node group.
+The below example demonstrates advanced configuration options for a managed node group.
 
 ```hcl
     managed_node_groups = {
@@ -49,6 +49,8 @@ The below example demonstrates advanced configuration options for a manged node 
         # 4> Node Group network configuration
         subnet_ids     = []                          # Mandatory - # Define private/public subnets list with comma separated ["subnet1","subnet2","subnet3"]
         k8s_taints     = []
+        # optionally, configure a taint on the node group:
+        # k8s_taints = [{key= "purpose", value="execution", "effect"="NO_SCHEDULE"}]
         k8s_labels     = {
           Environment = "preprod"
           Zone        = "dev"

--- a/examples/advanced/live/preprod/eu-west-1/application_acct/dev/main.tf
+++ b/examples/advanced/live/preprod/eu-west-1/application_acct/dev/main.tf
@@ -235,7 +235,7 @@ module "aws-eks-accelerator-for-terraform" {
 
       subnet_ids  = []        # Define your private/public subnets list with comma seprated subnet_ids  = ['subnet1','subnet2','subnet3']
 
-      k8s_taints = {}
+      k8s_taints = []
       k8s_labels = {
         Environment = "preprod"
         Zone        = "dev"
@@ -334,7 +334,6 @@ module "aws-eks-accelerator-for-terraform" {
 
       subnet_ids  = []        # Define your private/public subnets list with comma seprated subnet_ids  = ['subnet1','subnet2','subnet3']
 
-      k8s_taints = []
       k8s_labels = {
         Environment = "preprod"
         Zone        = "dev"
@@ -372,8 +371,6 @@ module "aws-eks-accelerator-for-terraform" {
 
 
       subnet_ids  = []        # Define your private/public subnets list with comma seprated subnet_ids  = ['subnet1','subnet2','subnet3']
-
-      k8s_taints = []
 
       k8s_labels = {
         Environment = "preprod"

--- a/modules/aws-eks-fargate-profiles/locals.tf
+++ b/modules/aws-eks-fargate-profiles/locals.tf
@@ -5,7 +5,6 @@ locals {
     fargate_profile_namespaces = []
     create_iam_role            = true
     k8s_labels                 = {}
-    k8s_taints                 = []
     additional_tags            = {}
     subnet_ids                 = []
   }

--- a/modules/aws-eks-managed-node-groups/README.md
+++ b/modules/aws-eks-managed-node-groups/README.md
@@ -43,6 +43,8 @@ This module allows you to create ON-DEMAND, SPOT and BOTTLEROCKET(with custom am
       subnet_ids  = []        # Define your private/public subnets list with comma seprated subnet_ids  = ['subnet1','subnet2','subnet3']
 
       k8s_taints = []
+      # optionally, configure a taint on the node group:
+      # k8s_taints = [{key= "purpose", value="execution", "effect"="NO_SCHEDULE"}]
 
       k8s_labels = {
         Environment = "preprod"


### PR DESCRIPTION
### What does this PR do?

- Adds examples for k8_taints in the managed-node-group documentation files.
- Removes k8s_taints from examples that passed them into self-managed node groups as EKS only supports taints through [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/node-taints-managed-node-groups.html).
- Removes k8_taints local from the aws-eks-fargate-profile module `locals.tf` for the same reason as above, and it wasn't being used.


### Motivation

Addressing a [documentation request](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/issues/205) for k8s_taints for managed node groups. Thanks for reporting this [schwichti](https://github.com/schwichti)!

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

