### PR TITLE
Replaced hardcoded value '3' with local.count_availability_zone to solve deployment issues with  regions with less AZss

### DIFF
--- a/examples/analytics/emr-on-eks/README.md
+++ b/examples/analytics/emr-on-eks/README.md
@@ -33,7 +33,7 @@ terraform init
 Set AWS_REGION and Run Terraform plan to verify the resources created by this execution.
 
 ```
-export AWS_REGION="<enter-your-region>"   
+export AWS_REGION="<enter-your-region>"  
 terraform plan
 
 ```
@@ -134,10 +134,25 @@ Specifically, you can use persistent volume claims if the jobs require large shu
 
       spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-1.options.claimName=OnDemand
       spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-1.options.storageClass=gp
-      spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-1.options.sizeLimit=500Gi
+      spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-1.options.sizeLimit=500Gipwd
+
       spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-1.mount.path=/data
       spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-1.mount.readOnly=false
+## Debugging
 
+##### Issue1: Error: local-exec provisioner error
+```shell script
+Error: local-exec provisioner error \
+with module.aws-eks-accelerator-for-terraform.module.emr_on_eks["data_team_b"].null_resource.update_trust_policy,\
+ on .terraform/modules/aws-eks-accelerator-for-terraform/modules/emr-on-eks/main.tf line 105, in resource "null_resource" \
+ "update_trust_policy":│ 105: provisioner "local-exec" {│ │ Error running command 'set -e│ │ aws emr-containers update-role-trust-policy \
+ │ --cluster-name aws001-preprod-test-eks \│ --namespace emr-data-team-b \│ --role-name aws001-preprod-test-eks-emr-eks-data-team-b
+```
+
+##### Solution :  
+ - emr-containers not present in cli version 2.0.41 Python/3.7.4. For more [details](https://github.com/aws/aws-cli/issues/6162)
+This is fixed in version 2.0.54.
+- Action: aws cli version should be updated to 2.0.54 or later : Execute  `pip install --upgrade awscliv2 `
 
 <!--- BEGIN_TF_DOCS --->
 ## Requirements

--- a/examples/analytics/emr-on-eks/README.md
+++ b/examples/analytics/emr-on-eks/README.md
@@ -13,6 +13,8 @@ Ensure that you have installed the following tools on your machine.
 3. [kubectl](https://Kubernetes.io/docs/tasks/tools/)
 4. [terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 
+Note :Currently Amazon Prometheus is supported only in selected regions. Please see this [userguide](https://docs.aws.amazon.com/prometheus/latest/userguide/what-is-Amazon-Managed-Service-Prometheus.html)
+
 ## Step1: Deploy EKS Clusters with EMR on EKS feature
 
 Clone the repository
@@ -28,10 +30,10 @@ cd examples/analytics/emr-on-eks
 terraform init
 ```
 
-Run Terraform plan to verify the resources created by this execution.
+Set AWS_REGION and Run Terraform plan to verify the resources created by this execution.
 
 ```
-export AWS_REGION="eu-west-1"   # Select your own region
+export AWS_REGION="<enter-your-region>"   
 terraform plan
 
 ```

--- a/examples/analytics/emr-on-eks/main.tf
+++ b/examples/analytics/emr-on-eks/main.tf
@@ -53,11 +53,11 @@ data "aws_eks_cluster_auth" "cluster" {
 }
 
 locals {
-  tenant      = "aws001"  # AWS account name or unique id for tenant
-  environment = "preprod" # Environment area eg., preprod or prod
-  zone        = "test"    # Environment with in one sub_tenant or business unit
-
-  kubernetes_version = "1.21"
+  tenant                  = "aws001"  # AWS account name or unique id for tenant
+  environment             = "preprod" # Environment area eg., preprod or prod
+  zone                    = "test"    # Environment with in one sub_tenant or business unit
+  count_availability_zone = (length(data.aws_availability_zones.available.names) <= 3) ? length(data.aws_availability_zones.available.zone_ids) : 3
+  kubernetes_version      = "1.21"
 
   vpc_cidr     = "10.0.0.0/16"
   vpc_name     = join("-", [local.tenant, local.environment, local.zone, "vpc"])
@@ -74,8 +74,8 @@ module "aws_vpc" {
   cidr = local.vpc_cidr
   azs  = data.aws_availability_zones.available.names
 
-  public_subnets  = [for k, v in slice(data.aws_availability_zones.available.names, 0, 3) : cidrsubnet(local.vpc_cidr, 8, k)]
-  private_subnets = [for k, v in slice(data.aws_availability_zones.available.names, 0, 3) : cidrsubnet(local.vpc_cidr, 8, k + 10)]
+  public_subnets  = [for k, v in slice(data.aws_availability_zones.available.names, 0, local.count_availability_zone) : cidrsubnet(local.vpc_cidr, 8, k)]
+  private_subnets = [for k, v in slice(data.aws_availability_zones.available.names, 0, local.count_availability_zone) : cidrsubnet(local.vpc_cidr, 8, k + 10)]
 
   enable_nat_gateway   = true
   create_igw           = true


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Replaced hardcoded value '3'  in main file with local.count_availability_zone to solve deployment issues in regions with less than 3 AZs

### Motivation

<!-- What inspired you to submit this pull request? -->
Issue : 
While testing   emr-on-eks example on region : US-WEST-1 : 
`Error: Invalid function argument│ │ on main.tf line 77, in module "aws_vpc":│ 77: public_subnets = [for k, v in slice(data.aws_availability_zones.available.names, 0, 3) : cidrsubnet(local.vpc_cidr, 8, k)]│ │ Invalid value for "end_index" parameter: end index must not be greater than the length of the list.╵ `

### More

- [X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [X] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
Tested the code in us-west-1  region and us-east-1  after the fix . Its working fine 
us-west-1  have 2 AZs and us-east-1 have 3 Azs
we limit the AZs to 3 , In case if any region have more than 3 AZs , we are limiting it to 3 AZs for this example
