### PR TITLE
Feature/25 external dns add on

### DIFF
--- a/.github/workflows/examples-tfplan-tests.yml
+++ b/.github/workflows/examples-tfplan-tests.yml
@@ -27,6 +27,7 @@ jobs:
             examples/argocd,
             examples/aws-efs-csi-driver,
             examples/crossplane,
+            examples/eks-cluster-with-external-dns,
             examples/eks-cluster-with-new-vpc,
             examples/fully-private-eks-cluster,
             examples/game-tech/agones-game-controller,

--- a/docs/add-ons/argocd.md
+++ b/docs/add-ons/argocd.md
@@ -45,7 +45,7 @@ argocd_helm_config = {
 
 The framework provides an approach to bootstrapping workloads and/or additional add-ons by leveraging the ArgoCD [App of Apps](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/) pattern.
 
-The following code example demonstrates how you can supply information for a repository in order to bootstrap multiple workloads in a new EKS cluster. The example leverages a [sample App of Apps repository](https://github.com/aws-samples/ssp-eks-workloads.git) that ships with the EKS SSP solution.
+The following code example demonstrates how you can supply information for a repository in order to bootstrap multiple workloads in a new EKS cluster. The example leverages a [sample App of Apps repository](https://github.com/aws-samples/eks-blueprints-workloads.git).
 
 ```hcl
 argocd_applications = {
@@ -127,7 +127,7 @@ argocd_helm_config = {
 argocd_applications = {
   workloads = {
     path                = "envs/dev"
-    repo_url            = "https://github.com/aws-samples/ssp-eks-workloads.git"
+    repo_url            = "https://github.com/aws-samples/eks-blueprints-workloads.git"
     values              = {}
   }
   addons = {

--- a/docs/add-ons/external-dns.md
+++ b/docs/add-ons/external-dns.md
@@ -1,0 +1,44 @@
+# ExternalDNS
+
+[External DNS](https://github.com/kubernetes-sigs/external-dns) is a Kubernetes add-on that can automate the management of DNS records based on Ingress and Service resources. 
+
+For complete project documentation, please visit the [External DNS Github repository](https://github.com/kubernetes-sigs/external-dns).
+
+## Usage
+
+External DNS can be deployed by enabling the add-on via the following.
+
+```hcl
+enable_external_dns = true
+```
+
+External DNS can optionally leverage the `eks_cluster_domain` global property of the `kubernetes_addon` submodule. The value for this property should be a Route53 domain managed by your account. ExternalDNS will leverage the value supplied for its `zoneIdFilters` property, which will restrict ExternalDNS to only create records for this domain. See docs [here](https://github.com/bitnami/charts/tree/master/bitnami/external-dns).
+
+```
+eks_cluster_domain = <cluster_domain>
+```
+
+You can optionally customize the Helm chart that deploys `external-dns` via the following configuration.
+
+```hcl
+  enable_external_dns = true
+  external_dns_helm_config = {
+    name                       = "external-dns"
+    chart                      = "external-dns"
+    repository                 = "https://charts.bitnami.com/bitnami"
+    version                    = "6.1.6"
+    namespace                  = "external-dns"
+  }
+```
+
+### GitOps Configuration
+
+The following properties are made available for use when managing the add-on via GitOps.
+
+```
+external_dns = {
+  enable            = true
+  zoneFilterIds     = local.zone_filter_ids
+  serviceAccontName = local.service_account_name
+}
+```

--- a/docs/add-ons/index.md
+++ b/docs/add-ons/index.md
@@ -16,6 +16,7 @@ The framework currently provides support for the following add-ons:
 | [AWS Node Termination Handler](../add-ons/aws-node-termination-handler.md) | Deploys the AWS Node Termination Handler into an EKS cluster. |
 | [cert-manager](../add-ons/cert-manager.md) | Deploys cert-manager into an EKS cluster. |
 | [Cluster Autoscaler](../add-ons/cluster-autoscaler.md) | Deploys the standard cluster autoscaler into an EKS cluster. |
+| [ExternalDNS](../add-ons/external-dns.md) | Deploys External DNS into an EKS cluster. |
 | [Fargate Fluent Bit](../add-ons/fargate-fluent-bit.md) | Adds Fluent Bit support for EKS Fargate |
 | [Karpenter](../add-ons/karpenter.md) | Deploys Karpenter into an EKS cluster. |
 | [Keda](../add-ons/keda.md) | Deploys Keda into an EKS cluster. |

--- a/examples/eks-cluster-with-external-dns/README.md
+++ b/examples/eks-cluster-with-external-dns/README.md
@@ -99,4 +99,55 @@ terraform destroy --auto-approve
 ```
 
 <!--- BEGIN_TF_DOCS --->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.66.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.6.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.66.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_aws_vpc"></a> [aws\_vpc](#module\_aws\_vpc) | terraform-aws-modules/vpc/aws | 3.2.0 |
+| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | ../.. | n/a |
+| <a name="module_kubernetes-addons"></a> [kubernetes-addons](#module\_kubernetes-addons) | ../../modules/kubernetes-addons | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_acm_certificate.issued](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acm_certificate) | data source |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_eks_cluster_auth.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_route53_zone.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_acm_certificate_domain"></a> [acm\_certificate\_domain](#input\_acm\_certificate\_domain) | *.example.com | `string` | n/a | yes |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Kubernetes Version | `string` | `"1.21"` | no |
+| <a name="input_eks_cluster_domain"></a> [eks\_cluster\_domain](#input\_eks\_cluster\_domain) | Route53 domain for the cluster. | `string` | `"example.com"` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment area, e.g. prod or preprod | `string` | `"preprod"` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | Account Name or unique account unique id e.g., apps or management or aws007 | `string` | `"aws001"` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | zone, e.g. dev or qa or load or ops etc... | `string` | `"dev"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_configure_kubectl"></a> [configure\_kubectl](#output\_configure\_kubectl) | Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig |
+
 <!--- END_TF_DOCS --->

--- a/examples/eks-cluster-with-external-dns/README.md
+++ b/examples/eks-cluster-with-external-dns/README.md
@@ -1,0 +1,102 @@
+# EKS Cluster with External DNS
+
+This example demonstrates how to leverage External DNS, in concert with Ingress Nginx and AWS Load Balancer Controller. It demonstrates how you can easily provision multiple services with secure, custom domains which sit behind a single load balancer. 
+
+The pattern deploys the sample workloads that reside in the [EKS Blueprints Workloads repo](https://github.com/aws-samples/eks-blueprints-workloads) via ArgoCD. The [configuration for `team-riker`](https://github.com/aws-samples/eks-blueprints-workloads/tree/main/teams/team-riker/dev/templates) will deploy an Ingress resource which contains configuration for both path-based routing and the custom hostname for the `team-riker` service. Once the pattern is deployed, you will be able to reach the `team-riker` sample workload via a custom domain you supply.
+
+## How to Deploy
+
+### Prerequisites:
+
+#### Tools 
+
+Ensure that you have installed the following tools in your Mac or Windows Laptop before start working with this module and run Terraform Plan and Apply
+1. [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+3. [Kubectl](https://Kubernetes.io/docs/tasks/tools/)
+4. [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+
+#### AWS Resources 
+
+This example requires the following AWS resources:
+
+* A Route53 Hosted Zone for a domain that you own. 
+* A SSL/TLS certificate for your domain stored in AWS Certificate Manager (ACM). 
+ 
+For information on Route53 Hosted Zones, [see Route53 documentation](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-working-with.html). For instructions on requesting a SSL/TLS certificate for your domain, see [ACM docs](https://docs.aws.amazon.com/acm/latest/userguide/gs.html). 
+
+### Deployment Steps
+
+#### Step1: Clone the repo
+
+```shell script
+git clone https://github.com/aws-samples/aws-eks-accelerator-for-terraform.git
+```
+
+#### Step2: Terraform INIT
+
+Initialize a working directory with configuration files
+
+```shell script
+cd examples/eks-cluster-with-external-dns
+terraform init
+```
+
+#### Step3: Replace placeholder values in terraform.tfvars
+
+Both values in `terraform.tfvars` must be updated. 
+
+* `eks_cluster_domain` - the domain for your cluster. Value is used to look up a Route53 Hosted Zone that you own. DNS records created by `ExternalDNS` will be created in this Hosted Zone.
+* `acm_certificate_domain` - the domain for a certificate in ACM that will be leveraged by `Ingress Nginx`. Value is used to look up an ACM certificate that will be used to terminate HTTPS connections. This value should likely be a wildcard cert for your `eks_cluster_domain`.  
+
+```
+eks_cluster_domain      = "example.com"
+acm_certificate_domain  = "*.example.com"
+```
+
+#### Step3: Terraform PLAN
+Verify the resources created by this execution
+
+```shell script
+export AWS_REGION=<ENTER YOUR REGION>   # Select your own region
+terraform plan
+```
+
+#### Step4: Terraform APPLY
+
+```shell script
+terraform apply
+```
+
+Enter `yes` to apply
+
+#### Step5: Update local kubeconfig
+
+`~/.kube/config` file gets updated with cluster details and certificate from the below command.
+
+    $ aws eks --region <enter-your-region> update-kubeconfig --name <cluster-name>
+
+#### Step6: List all the worker nodes by running the command below
+
+    $ kubectl get nodes
+
+#### Step7: List all the pods running in `kube-system` namespace
+
+    $ kubectl get pods -n kube-system
+
+
+#### Step 8: Verify the Ingress resource was created for Team Riker
+
+    $ kubectl get ingress -n team-riker
+
+Navigate to the HOST url which should be `guestbook-ui.<eks_cluster_domain>`. At this point, you should be able to view the `guestbook-ui` application in the browser at the HOST url.
+
+## How to Destroy
+
+The following command destroys the resources created by `terraform apply`
+
+```shell script
+terraform destroy --auto-approve
+```
+
+<!--- BEGIN_TF_DOCS --->
+<!--- END_TF_DOCS --->

--- a/examples/eks-cluster-with-external-dns/main.tf
+++ b/examples/eks-cluster-with-external-dns/main.tf
@@ -26,15 +26,24 @@ data "aws_region" "current" {}
 data "aws_availability_zones" "available" {}
 
 data "aws_eks_cluster" "cluster" {
-  name = module.aws-eks-accelerator-for-terraform.eks_cluster_id
+  name = module.eks_cluster.eks_cluster_id
 }
 
 data "aws_eks_cluster_auth" "cluster" {
-  name = module.aws-eks-accelerator-for-terraform.eks_cluster_id
+  name = module.eks_cluster.eks_cluster_id
+}
+
+data "aws_acm_certificate" "issued" {
+  domain   = var.acm_certificate_domain
+  statuses = ["ISSUED"]
+}
+
+data "aws_route53_zone" "selected" {
+  name = var.eks_cluster_domain
 }
 
 provider "aws" {
-  region = "us-west-2"
+  region = data.aws_region.current.id
   alias  = "default"
 }
 
@@ -56,38 +65,17 @@ provider "helm" {
 }
 
 locals {
-  tenant      = var.tenant      # AWS account name or unique id for tenant
-  environment = var.environment # Environment area eg., preprod or prod
-  zone        = var.zone        # Environment with in one sub_tenant or business unit
-
-  cluster_version = var.cluster_version
+  tenant          = "aws001"  # AWS account name or unique id for tenant
+  environment     = "preprod" # Environment area eg., preprod or prod
+  zone            = "dev"     # Environment with in one sub_tenant or business unit
+  cluster_version = "1.21"
 
   vpc_cidr     = "10.0.0.0/16"
   vpc_name     = join("-", [local.tenant, local.environment, local.zone, "vpc"])
-  azs          = slice(data.aws_availability_zones.available.names, 0, 3)
   cluster_name = join("-", [local.tenant, local.environment, local.zone, "eks"])
+  azs          = slice(data.aws_availability_zones.available.names, 0, 3)
 
   terraform_version = "Terraform v1.0.1"
-
-  #---------------------------------------------------------------
-  # ARGOCD ADD-ON APPLICATION
-  #---------------------------------------------------------------
-
-  addon_application = {
-    path               = "chart"
-    repo_url           = "https://github.com/aws-samples/ssp-eks-add-ons.git"
-    add_on_application = true
-  }
-
-  #---------------------------------------------------------------
-  # ARGOCD WORKLOAD APPLICATION
-  #---------------------------------------------------------------
-
-  workload_application = {
-    path               = "envs/dev"
-    repo_url           = "https://github.com/aws-samples/eks-blueprints-workloads.git"
-    add_on_application = false
-  }
 }
 
 #---------------------------------------------------------------
@@ -96,7 +84,7 @@ locals {
 
 module "aws_vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "v3.2.0"
+  version = "3.2.0"
 
   name = local.vpc_name
   cidr = local.vpc_cidr
@@ -122,11 +110,11 @@ module "aws_vpc" {
 }
 
 #---------------------------------------------------------------
-# Example to consume aws-eks-accelerator-for-terraform module
+# Example to consume eks_cluster module
 #---------------------------------------------------------------
 
-module "aws-eks-accelerator-for-terraform" {
-  source = "../../../"
+module "eks_cluster" {
+  source = "../.."
 
   tenant            = local.tenant
   environment       = local.environment
@@ -144,49 +132,68 @@ module "aws-eks-accelerator-for-terraform" {
   managed_node_groups = {
     mg_4 = {
       node_group_name = "managed-ondemand"
-      instance_types  = ["m5.large"]
+      instance_types  = ["m4.large"]
+      min_size        = "2"
       subnet_ids      = module.aws_vpc.private_subnets
-
-      desired_size = "5"
-      max_size     = "10"
-      min_size     = "3"
     }
   }
 }
 
 module "kubernetes-addons" {
-  source = "../../../modules/kubernetes-addons"
+  source = "../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.aws-eks-accelerator-for-terraform.eks_cluster_id
+  #---------------------------------------------------------------
+  # Globals
+  #---------------------------------------------------------------
+
+  eks_cluster_id     = module.eks_cluster.eks_cluster_id
+  eks_cluster_domain = var.eks_cluster_domain
 
   #---------------------------------------------------------------
   # ARGO CD ADD-ON
   #---------------------------------------------------------------
 
-  enable_argocd         = true
-  argocd_manage_add_ons = true # Indicates that ArgoCD is responsible for managing/deploying Add-ons.
+  enable_argocd = true
   argocd_applications = {
-    addons    = local.addon_application
-    workloads = local.workload_application
+    workloads = {
+      path     = "envs/dev"
+      repo_url = "https://github.com/aws-samples/eks-blueprints-workloads.git"
+      values = {
+        spec = {
+          ingress = {
+            host = var.eks_cluster_domain
+          }
+        }
+      }
+    }
   }
 
   #---------------------------------------------------------------
-  # ADD-ONS
+  # INGRESS NGINX ADD-ON
   #---------------------------------------------------------------
 
-  enable_aws_for_fluentbit            = true
-  enable_aws_load_balancer_controller = true
-  enable_cert_manager                 = true
-  enable_cluster_autoscaler           = true
-  enable_ingress_nginx                = true
-  enable_karpenter                    = true
-  enable_keda                         = true
-  enable_metrics_server               = true
-  enable_prometheus                   = true
-  enable_traefik                      = true
-  enable_vpa                          = true
-  enable_yunikorn                     = true
-  enable_argo_rollouts                = true
+  enable_ingress_nginx = true
+  ingress_nginx_helm_config = {
+    values = [templatefile("${path.module}/nginx-values.yaml", {
+      hostname     = var.eks_cluster_domain
+      ssl_cert_arn = data.aws_acm_certificate.issued.arn
+    })]
+  }
 
-  depends_on = [module.aws-eks-accelerator-for-terraform.managed_node_groups]
+  #---------------------------------------------------------------
+  # OTHER ADD-ONS
+  #---------------------------------------------------------------
+
+  enable_aws_load_balancer_controller = true
+  enable_external_dns                 = true
+
+  depends_on = [
+    module.aws_vpc,
+    module.eks_cluster.managed_node_groups
+  ]
+}
+
+output "configure_kubectl" {
+  description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
+  value       = module.eks_cluster.configure_kubectl
 }

--- a/examples/eks-cluster-with-external-dns/nginx-values.yaml
+++ b/examples/eks-cluster-with-external-dns/nginx-values.yaml
@@ -1,0 +1,21 @@
+controller:
+  service:
+    type: LoadBalancer
+    externalTrafficPolicy: "Local"
+    annotations:
+      # AWS Load Balancer Controller Annotations
+      service.beta.kubernetes.io/aws-load-balancer-type: external
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+      service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+
+      # SSL Annotations
+      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: ${ssl_cert_arn}
+      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: '443'
+
+      # External DNS Annotations
+      external-dns.alpha.kubernetes.io/hostname: ${hostname}
+
+    targetPorts:
+      http: http
+      https: http

--- a/examples/eks-cluster-with-external-dns/terraform.tfvars
+++ b/examples/eks-cluster-with-external-dns/terraform.tfvars
@@ -1,0 +1,2 @@
+eks_cluster_domain     = "example.com"
+acm_certificate_domain = "*.example.com"

--- a/examples/eks-cluster-with-external-dns/variables.tf
+++ b/examples/eks-cluster-with-external-dns/variables.tf
@@ -1,0 +1,9 @@
+variable "eks_cluster_domain" {
+  type        = string
+  description = "Route53 domain for the cluster."
+}
+
+variable "acm_certificate_domain" {
+  type        = string
+  description = "ACM Certificate domain for the cluster."
+}

--- a/examples/eks-cluster-with-external-dns/variables.tf
+++ b/examples/eks-cluster-with-external-dns/variables.tf
@@ -1,9 +1,34 @@
+variable "cluster_version" {
+  type        = string
+  description = "Kubernetes Version"
+  default     = "1.21"
+}
+
+variable "tenant" {
+  type        = string
+  description = "Account Name or unique account unique id e.g., apps or management or aws007"
+  default     = "aws001"
+}
+
+variable "environment" {
+  type        = string
+  default     = "preprod"
+  description = "Environment area, e.g. prod or preprod "
+}
+
+variable "zone" {
+  type        = string
+  description = "zone, e.g. dev or qa or load or ops etc..."
+  default     = "dev"
+}
+
 variable "eks_cluster_domain" {
   type        = string
   description = "Route53 domain for the cluster."
+  default     = "example.com"
 }
 
 variable "acm_certificate_domain" {
   type        = string
-  description = "ACM Certificate domain for the cluster."
+  description = "*.example.com"
 }

--- a/examples/observability/eks-cluster-with-amp-amg-opensearch/main.tf
+++ b/examples/observability/eks-cluster-with-amp-amg-opensearch/main.tf
@@ -42,7 +42,7 @@ locals {
   # Sample workload managed by ArgoCD. For generating metrics and logs
   workload_application = {
     path               = "envs/dev"
-    repo_url           = "https://github.com/aws-samples/ssp-eks-workloads.git"
+    repo_url           = "https://github.com/aws-samples/eks-blueprints-workloads.git"
     add_on_application = false
   }
 

--- a/locals.tf
+++ b/locals.tf
@@ -152,5 +152,4 @@ locals {
   ] : []
 
   cluster_iam_role_name = "${module.eks_tags.tags.name}-cluster-role"
-
 }

--- a/main.tf
+++ b/main.tf
@@ -85,7 +85,6 @@ module "aws_eks" {
   ] : var.cluster_encryption_config
 
   cluster_identity_providers = var.cluster_identity_providers
-
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -34,6 +34,7 @@
 | <a name="module_cert_manager"></a> [cert\_manager](#module\_cert\_manager) | ./cert-manager | n/a |
 | <a name="module_cluster_autoscaler"></a> [cluster\_autoscaler](#module\_cluster\_autoscaler) | ./cluster-autoscaler | n/a |
 | <a name="module_crossplane"></a> [crossplane](#module\_crossplane) | ./crossplane | n/a |
+| <a name="module_external_dns"></a> [external\_dns](#module\_external\_dns) | ./external-dns | n/a |
 | <a name="module_fargate_fluentbit"></a> [fargate\_fluentbit](#module\_fargate\_fluentbit) | ./fargate-fluentbit | n/a |
 | <a name="module_ingress_nginx"></a> [ingress\_nginx](#module\_ingress\_nginx) | ./ingress-nginx | n/a |
 | <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | ./karpenter | n/a |
@@ -86,6 +87,7 @@
 | <a name="input_crossplane_aws_provider"></a> [crossplane\_aws\_provider](#input\_crossplane\_aws\_provider) | AWS Provider config for Crossplane | <pre>object({<br>    enable                   = bool<br>    provider_aws_version     = string<br>    additional_irsa_policies = list(string)<br>  })</pre> | <pre>{<br>  "additional_irsa_policies": [],<br>  "enable": false,<br>  "provider_aws_version": "v0.24.1"<br>}</pre> | no |
 | <a name="input_crossplane_helm_config"></a> [crossplane\_helm\_config](#input\_crossplane\_helm\_config) | Crossplane Helm Chart config | `any` | `null` | no |
 | <a name="input_crossplane_jet_aws_provider"></a> [crossplane\_jet\_aws\_provider](#input\_crossplane\_jet\_aws\_provider) | AWS Provider Jet AWS config for Crossplane | <pre>object({<br>    enable                   = bool<br>    provider_aws_version     = string<br>    additional_irsa_policies = list(string)<br>  })</pre> | <pre>{<br>  "additional_irsa_policies": [],<br>  "enable": false,<br>  "provider_aws_version": "v0.24.1"<br>}</pre> | no |
+| <a name="input_eks_cluster_domain"></a> [eks\_cluster\_domain](#input\_eks\_cluster\_domain) | The domain for the EKS cluster. | `string` | `""` | no |
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | EKS Cluster Id | `string` | n/a | yes |
 | <a name="input_eks_worker_security_group_id"></a> [eks\_worker\_security\_group\_id](#input\_eks\_worker\_security\_group\_id) | EKS Worker Security group Id created by EKS module | `string` | `""` | no |
 | <a name="input_enable_agones"></a> [enable\_agones](#input\_enable\_agones) | Enable Agones GamServer add-on | `bool` | `false` | no |
@@ -103,6 +105,7 @@
 | <a name="input_enable_cert_manager"></a> [enable\_cert\_manager](#input\_enable\_cert\_manager) | Enable Cert Manager add-on | `bool` | `false` | no |
 | <a name="input_enable_cluster_autoscaler"></a> [enable\_cluster\_autoscaler](#input\_enable\_cluster\_autoscaler) | Enable Cluster autoscaler add-on | `bool` | `false` | no |
 | <a name="input_enable_crossplane"></a> [enable\_crossplane](#input\_enable\_crossplane) | Enable Crossplane add-on | `bool` | `false` | no |
+| <a name="input_enable_external_dns"></a> [enable\_external\_dns](#input\_enable\_external\_dns) | External DNS add-on. | `bool` | `false` | no |
 | <a name="input_enable_fargate_fluentbit"></a> [enable\_fargate\_fluentbit](#input\_enable\_fargate\_fluentbit) | Enable Fargate FluentBit add-on | `bool` | `false` | no |
 | <a name="input_enable_ingress_nginx"></a> [enable\_ingress\_nginx](#input\_enable\_ingress\_nginx) | Enable Ingress Nginx add-on | `bool` | `false` | no |
 | <a name="input_enable_ipv6"></a> [enable\_ipv6](#input\_enable\_ipv6) | Enable Ipv6 network. Attaches new VPC CNI policy to the IRSA role | `bool` | `false` | no |
@@ -116,6 +119,8 @@
 | <a name="input_enable_traefik"></a> [enable\_traefik](#input\_enable\_traefik) | Enable Traefik add-on | `bool` | `false` | no |
 | <a name="input_enable_vpa"></a> [enable\_vpa](#input\_enable\_vpa) | Enable Vertical Pod Autoscaler add-on | `bool` | `false` | no |
 | <a name="input_enable_yunikorn"></a> [enable\_yunikorn](#input\_enable\_yunikorn) | Enable Apache YuniKorn K8s scheduler add-on | `bool` | `false` | no |
+| <a name="input_external_dns_helm_config"></a> [external\_dns\_helm\_config](#input\_external\_dns\_helm\_config) | External DNS Helm Chart config | `any` | `{}` | no |
+| <a name="input_external_dns_irsa_policies"></a> [external\_dns\_irsa\_policies](#input\_external\_dns\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
 | <a name="input_fargate_fluentbit_addon_config"></a> [fargate\_fluentbit\_addon\_config](#input\_fargate\_fluentbit\_addon\_config) | Fargate fluentbit add-on config | `any` | `{}` | no |
 | <a name="input_ingress_nginx_helm_config"></a> [ingress\_nginx\_helm\_config](#input\_ingress\_nginx\_helm\_config) | Ingress Nginx Helm Chart config | `any` | `{}` | no |
 | <a name="input_irsa_iam_permissions_boundary"></a> [irsa\_iam\_permissions\_boundary](#input\_irsa\_iam\_permissions\_boundary) | IAM permissions boundary for IRSA roles | `string` | `""` | no |
@@ -126,6 +131,7 @@
 | <a name="input_keda_helm_config"></a> [keda\_helm\_config](#input\_keda\_helm\_config) | KEDA Event-based autoscaler add-on config | `any` | `{}` | no |
 | <a name="input_keda_irsa_policies"></a> [keda\_irsa\_policies](#input\_keda\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
 | <a name="input_kubernetes_dashboard_helm_config"></a> [kubernetes\_dashboard\_helm\_config](#input\_kubernetes\_dashboard\_helm\_config) | Kubernetes Dashboard Helm Chart config | `any` | `null` | no |
+| <a name="input_kubernetes_dashboard_irsa_policies"></a> [kubernetes\_dashboard\_irsa\_policies](#input\_kubernetes\_dashboard\_irsa\_policies) | IAM policy ARNs for Kubernetes Dashboard IRSA | `list(string)` | `[]` | no |
 | <a name="input_metrics_server_helm_config"></a> [metrics\_server\_helm\_config](#input\_metrics\_server\_helm\_config) | Metrics Server Helm Chart config | `any` | `{}` | no |
 | <a name="input_node_groups_iam_role_arn"></a> [node\_groups\_iam\_role\_arn](#input\_node\_groups\_iam\_role\_arn) | Node Groups IAM role ARNs | `list(string)` | `[]` | no |
 | <a name="input_prometheus_helm_config"></a> [prometheus\_helm\_config](#input\_prometheus\_helm\_config) | Community Prometheus Helm Chart config | `any` | `{}` | no |
@@ -143,7 +149,7 @@
 | <a name="input_tetrate_istio_version"></a> [tetrate\_istio\_version](#input\_tetrate\_istio\_version) | Istio version | `string` | `""` | no |
 | <a name="input_traefik_helm_config"></a> [traefik\_helm\_config](#input\_traefik\_helm\_config) | Traefik Helm Chart config | `any` | `{}` | no |
 | <a name="input_vpa_helm_config"></a> [vpa\_helm\_config](#input\_vpa\_helm\_config) | VPA Helm Chart config | `any` | `null` | no |
-| <a name="input_yunikorn_helm_config"></a> [yunikorn\_helm\_config](#input\_yunikorn\_helm\_config) | Yunikorn Helm Chart config | `any` | `null` | no |
+| <a name="input_yunikorn_helm_config"></a> [yunikorn\_helm\_config](#input\_yunikorn\_helm\_config) | YuniKorn Helm Chart config | `any` | `null` | no |
 | <a name="input_yunikorn_irsa_policies"></a> [yunikorn\_irsa\_policies](#input\_yunikorn\_irsa\_policies) | IAM policy ARNs for Yunikorn IRSA | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/modules/kubernetes-addons/external-dns/README.md
+++ b/modules/kubernetes-addons/external-dns/README.md
@@ -7,4 +7,45 @@
 For complete project documentation, please visit the [ExternalDNS Github repository](https://github.com/kubernetes-sigs/external-dns).
 
 <!--- BEGIN_TF_DOCS --->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_helm_addon"></a> [helm\_addon](#module\_helm\_addon) | ../helm-addon | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.external_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy_document.external_dns_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_route53_zone.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>    irsa_iam_role_path             = string<br>    irsa_iam_permissions_boundary  = string<br>  })</pre> | n/a | yes |
+| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain name of the Route53 hosted zone to use with External DNS. | `string` | n/a | yes |
+| <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | External DNS Helm Configuration | `any` | `{}` | no |
+| <a name="input_irsa_policies"></a> [irsa\_policies](#input\_irsa\_policies) | Additional IAM policies used for the add-on service account. | `list(string)` | n/a | yes |
+| <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_argocd_gitops_config"></a> [argocd\_gitops\_config](#output\_argocd\_gitops\_config) | Configuration used for managing the add-on with GitOps |
+| <a name="output_zone_filter_ids"></a> [zone\_filter\_ids](#output\_zone\_filter\_ids) | Zone Filter Ids for the add-on |
+
 <!--- END_TF_DOCS --->

--- a/modules/kubernetes-addons/external-dns/README.md
+++ b/modules/kubernetes-addons/external-dns/README.md
@@ -1,0 +1,10 @@
+# External DNS Helm Chart
+
+## Introduction
+
+[External DNS](https://github.com/kubernetes-sigs/external-dns) is a Kubernetes add-on that can automate the management of DNS records based on Ingress and Service resources. 
+
+For complete project documentation, please visit the [ExternalDNS Github repository](https://github.com/kubernetes-sigs/external-dns).
+
+<!--- BEGIN_TF_DOCS --->
+<!--- END_TF_DOCS --->

--- a/modules/kubernetes-addons/external-dns/data.tf
+++ b/modules/kubernetes-addons/external-dns/data.tf
@@ -1,0 +1,22 @@
+data "aws_route53_zone" "selected" {
+  name = var.domain_name
+}
+
+data "aws_iam_policy_document" "external_dns_iam_policy_document" {
+  statement {
+    effect    = "Allow"
+    resources = [data.aws_route53_zone.selected.arn]
+    actions = [
+      "route53:ChangeResourceRecordSets",
+      "route53:ListResourceRecordSets"
+    ]
+  }
+
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "route53:ListHostedZones"
+    ]
+  }
+}

--- a/modules/kubernetes-addons/external-dns/locals.tf
+++ b/modules/kubernetes-addons/external-dns/locals.tf
@@ -1,18 +1,23 @@
 locals {
-  name                 = "cert-manager"
+  name                 = "external-dns"
   service_account_name = "${local.name}-sa"
+  zone_filter_ids      = jsonencode([data.aws_route53_zone.selected.zone_id])
 
   default_helm_config = {
+    description = "ExternalDNS Helm Chart"
     name        = local.name
     chart       = local.name
-    repository  = "https://charts.jetstack.io"
-    version     = "v1.7.1"
+    repository  = "https://charts.bitnami.com/bitnami"
+    version     = "6.1.6"
     namespace   = local.name
-    description = "Cert Manager Add-on"
     values      = local.default_helm_values
   }
 
-  default_helm_values = [templatefile("${path.module}/values.yaml", {})]
+  default_helm_values = [templatefile("${path.module}/values.yaml", {
+    aws_region           = var.addon_context.aws_region_name
+    service_account_name = local.service_account_name
+    zone_filter_ids      = local.zone_filter_ids
+  })]
 
   helm_config = merge(
     local.default_helm_config,
@@ -35,10 +40,12 @@ locals {
     kubernetes_service_account        = local.service_account_name
     create_kubernetes_namespace       = true
     create_kubernetes_service_account = true
+    irsa_iam_policies                 = concat([aws_iam_policy.external_dns.arn], var.irsa_policies)
   }
 
   argocd_gitops_config = {
-    enable             = true
-    serviceAccountName = local.service_account_name
+    enable            = true
+    zoneFilterIds     = local.zone_filter_ids
+    serviceAccontName = local.service_account_name
   }
 }

--- a/modules/kubernetes-addons/external-dns/main.tf
+++ b/modules/kubernetes-addons/external-dns/main.tf
@@ -1,0 +1,23 @@
+//-------------------------------------
+// Helm Add-on
+//-------------------------------------
+
+module "helm_addon" {
+  source            = "../helm-addon"
+  helm_config       = local.helm_config
+  irsa_config       = local.irsa_config
+  set_values        = local.set_values
+  addon_context     = var.addon_context
+  manage_via_gitops = var.manage_via_gitops
+}
+
+//------------------------------------
+// IAM Policy
+//------------------------------------
+
+resource "aws_iam_policy" "external_dns" {
+  description = "External DNS IAM policy."
+  name        = "${var.addon_context.eks_cluster_id}-${local.helm_config["name"]}-irsa"
+  path        = var.addon_context.irsa_iam_role_path
+  policy      = data.aws_iam_policy_document.external_dns_iam_policy_document.json
+}

--- a/modules/kubernetes-addons/external-dns/outputs.tf
+++ b/modules/kubernetes-addons/external-dns/outputs.tf
@@ -1,0 +1,9 @@
+output "zone_filter_ids" {
+  description = "Zone Filter Ids for the add-on"
+  value       = local.zone_filter_ids
+}
+
+output "argocd_gitops_config" {
+  description = "Configuration used for managing the add-on with GitOps"
+  value       = var.manage_via_gitops ? local.argocd_gitops_config : null
+}

--- a/modules/kubernetes-addons/external-dns/values.yaml
+++ b/modules/kubernetes-addons/external-dns/values.yaml
@@ -1,0 +1,7 @@
+provider: aws
+zoneIdFilters: ${zone_filter_ids}
+aws:
+  region: ${aws_region}
+serviceAccount:
+    create: false
+    name: ${service_account_name}

--- a/modules/kubernetes-addons/external-dns/variables.tf
+++ b/modules/kubernetes-addons/external-dns/variables.tf
@@ -1,0 +1,38 @@
+variable "helm_config" {
+  type        = any
+  default     = {}
+  description = "External DNS Helm Configuration"
+}
+
+variable "manage_via_gitops" {
+  type        = bool
+  default     = false
+  description = "Determines if the add-on should be managed via GitOps."
+}
+
+variable "irsa_policies" {
+  type        = list(string)
+  description = "Additional IAM policies used for the add-on service account."
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Domain name of the Route53 hosted zone to use with External DNS."
+}
+
+variable "addon_context" {
+  type = object({
+    aws_caller_identity_account_id = string
+    aws_caller_identity_arn        = string
+    aws_eks_cluster_endpoint       = string
+    aws_partition_id               = string
+    aws_region_name                = string
+    eks_cluster_id                 = string
+    eks_oidc_issuer_url            = string
+    eks_oidc_provider_arn          = string
+    tags                           = map(string)
+    irsa_iam_role_path             = string
+    irsa_iam_permissions_boundary  = string
+  })
+  description = "Input configuration for the addon"
+}

--- a/modules/kubernetes-addons/ingress-nginx/locals.tf
+++ b/modules/kubernetes-addons/ingress-nginx/locals.tf
@@ -1,14 +1,12 @@
 locals {
-  name      = "ingress-nginx"
-  namespace = "nginx"
+  name = "ingress-nginx"
 
   default_helm_config = {
     name             = local.name
     chart            = local.name
     repository       = "https://kubernetes.github.io/ingress-nginx"
     version          = "4.0.17"
-    namespace        = local.namespace
-    timeout          = "1200"
+    namespace        = local.name
     create_namespace = false
     values           = local.default_helm_values
     set              = []

--- a/modules/kubernetes-addons/ingress-nginx/main.tf
+++ b/modules/kubernetes-addons/ingress-nginx/main.tf
@@ -1,3 +1,6 @@
+//-------------------------------------
+// Helm Add-on
+//-------------------------------------
 
 module "helm_addon" {
   source            = "../helm-addon"
@@ -8,6 +11,10 @@ module "helm_addon" {
 
   depends_on = [kubernetes_namespace_v1.this]
 }
+
+//-------------------------------------
+// Helm Namespace
+//-------------------------------------
 
 resource "kubernetes_namespace_v1" "this" {
   metadata {

--- a/modules/kubernetes-addons/ingress-nginx/values.yaml
+++ b/modules/kubernetes-addons/ingress-nginx/values.yaml
@@ -2,8 +2,10 @@ controller:
   service:
     externalTrafficPolicy: "Local"
     annotations:
-      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+      # AWS Load Balancer Controller Annotations
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp # or 'ssl'
+      service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
       service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '60'
-      service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
-      service.beta.kubernetes.io/aws-load-balancer-internal: "false"
-      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+      service.beta.kubernetes.io/aws-load-balancer-type: 'external'
+      service.beta.kubernetes.io/aws-load-balancer-scheme: 'internet-facing' # or 'internal'
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: 'ip'

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -123,6 +123,16 @@ module "crossplane" {
   addon_context     = local.addon_context
 }
 
+module "external_dns" {
+  count             = var.enable_external_dns ? 1 : 0
+  source            = "./external-dns"
+  helm_config       = var.external_dns_helm_config
+  manage_via_gitops = var.argocd_manage_add_ons
+  irsa_policies     = var.external_dns_irsa_policies
+  addon_context     = local.addon_context
+  domain_name       = var.eks_cluster_domain
+}
+
 module "fargate_fluentbit" {
   count         = var.enable_fargate_fluentbit ? 1 : 0
   source        = "./fargate-fluentbit"
@@ -153,6 +163,14 @@ module "keda" {
   source            = "./keda"
   helm_config       = var.keda_helm_config
   irsa_policies     = var.keda_irsa_policies
+  manage_via_gitops = var.argocd_manage_add_ons
+  addon_context     = local.addon_context
+}
+
+module "kubernetes_dashboard" {
+  count             = var.enable_kubernetes_dashboard ? 1 : 0
+  source            = "./kubernetes-dashboard"
+  helm_config       = var.kubernetes_dashboard_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
 }
@@ -223,14 +241,6 @@ module "yunikorn" {
   source            = "./yunikorn"
   helm_config       = var.yunikorn_helm_config
   irsa_policies     = var.yunikorn_irsa_policies
-  manage_via_gitops = var.argocd_manage_add_ons
-  addon_context     = local.addon_context
-}
-
-module "kubernetes_dashboard" {
-  count             = var.enable_kubernetes_dashboard ? 1 : 0
-  source            = "./kubernetes-dashboard"
-  helm_config       = var.kubernetes_dashboard_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
 }

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -3,6 +3,12 @@ variable "eks_cluster_id" {
   type        = string
 }
 
+variable "eks_cluster_domain" {
+  description = "The domain for the EKS cluster."
+  default     = ""
+  type        = string
+}
+
 variable "eks_worker_security_group_id" {
   description = "EKS Worker Security group Id created by EKS module"
   default     = ""
@@ -146,6 +152,25 @@ variable "crossplane_jet_aws_provider" {
     provider_aws_version     = "v0.24.1"
     additional_irsa_policies = []
   }
+}
+
+#-----------External DNS ADDON-------------
+variable "enable_external_dns" {
+  type        = bool
+  default     = false
+  description = "External DNS add-on."
+}
+
+variable "external_dns_helm_config" {
+  type        = any
+  default     = {}
+  description = "External DNS Helm Chart config"
+}
+
+variable "external_dns_irsa_policies" {
+  type        = list(string)
+  description = "Additional IAM policies for a IAM role for service accounts"
+  default     = []
 }
 
 #-----------Amazon Managed Service for Prometheus-------------
@@ -395,6 +420,19 @@ variable "cert_manager_helm_config" {
   default     = {}
 }
 
+#-----------Argo Rollouts ADDON-------------
+variable "enable_argo_rollouts" {
+  type        = bool
+  default     = false
+  description = "Enable Argo Rollouts add-on"
+}
+
+variable "argo_rollouts_helm_config" {
+  type        = any
+  default     = null
+  description = "Argo Rollouts Helm Chart config"
+}
+
 #-----------ARGOCD ADDON-------------
 variable "enable_argocd" {
   type        = bool
@@ -489,6 +527,25 @@ variable "keda_irsa_policies" {
   default     = []
 }
 
+#-----------Kubernetes Dashboard ADDON-------------
+variable "enable_kubernetes_dashboard" {
+  type        = bool
+  default     = false
+  description = "Enable Kubernetes Dashboard add-on"
+}
+
+variable "kubernetes_dashboard_helm_config" {
+  type        = any
+  default     = null
+  description = "Kubernetes Dashboard Helm Chart config"
+}
+
+variable "kubernetes_dashboard_irsa_policies" {
+  type        = list(string)
+  default     = []
+  description = "IAM policy ARNs for Kubernetes Dashboard IRSA"
+}
+
 #------Vertical Pod Autoscaler(VPA) ADDON--------
 variable "enable_vpa" {
   type        = bool
@@ -512,37 +569,11 @@ variable "enable_yunikorn" {
 variable "yunikorn_helm_config" {
   type        = any
   default     = null
-  description = "Yunikorn Helm Chart config"
+  description = "YuniKorn Helm Chart config"
 }
 
 variable "yunikorn_irsa_policies" {
   type        = list(string)
   default     = []
   description = "IAM policy ARNs for Yunikorn IRSA"
-}
-
-#-----------Argo Rollouts ADDON-------------
-variable "enable_argo_rollouts" {
-  type        = bool
-  default     = false
-  description = "Enable Argo Rollouts add-on"
-}
-
-variable "argo_rollouts_helm_config" {
-  type        = any
-  default     = null
-  description = "Argo Rollouts Helm Chart config"
-}
-
-#-----------Kubernetes Dashboard ADDON-------------
-variable "enable_kubernetes_dashboard" {
-  type        = bool
-  default     = false
-  description = "Enable Kubernetes Dashboard add-on"
-}
-
-variable "kubernetes_dashboard_helm_config" {
-  type        = any
-  default     = null
-  description = "Kubernetes Dashboard Helm Chart config"
 }


### PR DESCRIPTION
### What does this PR do?

This pull request adds support for an [External DNS](https://github.com/kubernetes-sigs/external-dns) add-on.

It also updates `ingress-nginx` add-on to remove boilerplate configuration.

### Motivation

Allow users to leverage External DNS in their EKS clusters.

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
