### PR TITLE
Feature/kubernetes dashboard add on

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.66.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.73.0 |
 | <a name="provider_http"></a> [http](#provider\_http) | 2.4.1 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.7.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.7.1 |
 
 ## Modules
 
@@ -247,7 +247,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 | <a name="output_teams"></a> [teams](#output\_teams) | Outputs from EKS Fargate profiles groups |
 | <a name="output_windows_node_group_aws_auth_config_map"></a> [windows\_node\_group\_aws\_auth\_config\_map](#output\_windows\_node\_group\_aws\_auth\_config\_map) | Windows node groups AWS auth map |
 | <a name="output_worker_security_group_id"></a> [worker\_security\_group\_id](#output\_worker\_security\_group\_id) | EKS Worker Security group ID created by EKS module |
-
 <!--- END_TF_DOCS --->
 
 ## Security

--- a/docs/add-ons/index.md
+++ b/docs/add-ons/index.md
@@ -25,6 +25,8 @@ The framework currently provides support for the following add-ons:
 | [Traefik](../add-ons/traefik.md) | Deploys Traefik Proxy into an EKS cluster.
 | [VPA](../add-ons/vpa.md) | Deploys the Vertical Pod Autoscaler into an EKS cluster. |
 | [YuniKorn](../add-ons/yunikorn.md) | Deploys Apache YuniKorn into an EKS cluster. |
+| [Kube State Metrics](../add-ons/kube-state-metrics.md) | Deploys Kube State Metrics into an EKS cluster. |
+| [Kubernetes Dashboard](../add-ons/kubernetes-dashboard.md) | Deploys Kubernetes Dashboard into an EKS cluster. |
 
 ## Add-on Management
 

--- a/docs/add-ons/kubernetes-dashboard.md
+++ b/docs/add-ons/kubernetes-dashboard.md
@@ -16,7 +16,7 @@ Enable Kubernetes Dashboard with custom `values.yaml`
   enable_kubernetes_dashboard = true
 
   # Optional Map value
-  kube_state_metrics_helm_config = {
+  kubernetes_dashboard_helm_config = {
     name       = "kubernetes-dashboard" # (Required) Release name.
     repository = "https://kubernetes.github.io/dashboard/" # (Optional) Repository URL where to locate the requested chart.
     chart      = "kubernetes-dashboard" # (Required) Chart name to be installed.
@@ -36,3 +36,7 @@ argocd_gitops_config = {
   serviceAccountName = local.service_account_name
 }
 ```
+
+### Connecting to the Dashboard
+
+Follow the steps outlined [here](https://docs.aws.amazon.com/eks/latest/userguide/dashboard-tutorial.html#view-dashboard) to connect to the dashboard

--- a/docs/add-ons/kubernetes-dashboard.md
+++ b/docs/add-ons/kubernetes-dashboard.md
@@ -1,0 +1,38 @@
+# Kubernetes Dashboard
+
+[Kubernetes Dashboard](https://github.com/kubernetes/dashboard) is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage applications running in the cluster and troubleshoot them, as well as manage the cluster itself.
+
+## Usage
+
+The following will deploy the Kubernetes Dashboard into an EKS Cluster.
+
+```hcl-terraform
+enable_kubernetes_dashboard = true
+```
+
+Enable Kubernetes Dashboard with custom `values.yaml`
+
+```hcl-terraform
+  enable_kubernetes_dashboard = true
+
+  # Optional Map value
+  kube_state_metrics_helm_config = {
+    name       = "kubernetes-dashboard" # (Required) Release name.
+    repository = "https://kubernetes.github.io/dashboard/" # (Optional) Repository URL where to locate the requested chart.
+    chart      = "kubernetes-dashboard" # (Required) Chart name to be installed.
+    version    = "5.2.0"
+    namespace  = "kube-system"
+    values = [templatefile("${path.module}/values.yaml", {})]
+  }
+```
+
+### GitOps Configuration
+
+The following properties are made available for use when managing the add-on via GitOps
+
+```hcl-terraform
+argocd_gitops_config = {
+  enable             = true
+  serviceAccountName = local.service_account_name
+}
+```

--- a/examples/eks-cluster-with-import-vpc/eks/main.tf
+++ b/examples/eks-cluster-with-import-vpc/eks/main.tf
@@ -100,6 +100,7 @@ module "kubernetes-addons" {
   enable_argocd                       = true
   enable_fargate_fluentbit            = false
   enable_argo_rollouts                = true
+  enable_kubernetes_dashboard         = true
 
   depends_on = [module.aws-eks-accelerator-for-terraform.managed_node_groups]
 }

--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -54,6 +54,7 @@ No providers.
 | <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | ./karpenter | n/a |
 | <a name="module_keda"></a> [keda](#module\_keda) | ./keda | n/a |
 | <a name="module_kube_state_metrics"></a> [kube\_state\_metrics](#module\_kube\_state\_metrics) | askulkarni2/kube-state-metrics-addon/eksblueprints | 0.0.2 |
+| <a name="module_kubernetes_dashboard"></a> [kubernetes\_dashboard](#module\_kubernetes\_dashboard) | ./kubernetes-dashboard | n/a |
 | <a name="module_metrics_server"></a> [metrics\_server](#module\_metrics\_server) | ./metrics-server | n/a |
 | <a name="module_prometheus"></a> [prometheus](#module\_prometheus) | ./prometheus | n/a |
 | <a name="module_spark_k8s_operator"></a> [spark\_k8s\_operator](#module\_spark\_k8s\_operator) | ./spark-k8s-operator | n/a |
@@ -69,6 +70,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_Kubernetes_dashboard_irsa_permissions_boundary"></a> [Kubernetes\_dashboard\_irsa\_permissions\_boundary](#input\_Kubernetes\_dashboard\_irsa\_permissions\_boundary) | IAM Policy ARN for IRSA IAM role permissions boundary | `string` | `""` | no |
 | <a name="input_agones_helm_config"></a> [agones\_helm\_config](#input\_agones\_helm\_config) | Agones GameServer Helm Chart config | `any` | `{}` | no |
 | <a name="input_amazon_eks_aws_ebs_csi_driver_config"></a> [amazon\_eks\_aws\_ebs\_csi\_driver\_config](#input\_amazon\_eks\_aws\_ebs\_csi\_driver\_config) | configMap for AWS EBS CSI Driver add-on | `any` | `{}` | no |
 | <a name="input_amazon_eks_coredns_config"></a> [amazon\_eks\_coredns\_config](#input\_amazon\_eks\_coredns\_config) | ConfigMap for Amazon CoreDNS EKS add-on | `any` | `{}` | no |
@@ -118,6 +120,7 @@ No resources.
 | <a name="input_enable_karpenter"></a> [enable\_karpenter](#input\_enable\_karpenter) | Enable Karpenter autoscaler add-on | `bool` | `false` | no |
 | <a name="input_enable_keda"></a> [enable\_keda](#input\_enable\_keda) | Enable KEDA Event-based autoscaler add-on | `bool` | `false` | no |
 | <a name="input_enable_kube_state_metrics"></a> [enable\_kube\_state\_metrics](#input\_enable\_kube\_state\_metrics) | Enable Kube State Metrics add-on | `bool` | `false` | no |
+| <a name="input_enable_kubernetes_dashboard"></a> [enable\_kubernetes\_dashboard](#input\_enable\_kubernetes\_dashboard) | Enable Kubernetes Dashboard add-on | `bool` | `false` | no |
 | <a name="input_enable_metrics_server"></a> [enable\_metrics\_server](#input\_enable\_metrics\_server) | Enable metrics server add-on | `bool` | `false` | no |
 | <a name="input_enable_prometheus"></a> [enable\_prometheus](#input\_enable\_prometheus) | Enable Community Prometheus add-on | `bool` | `false` | no |
 | <a name="input_enable_spark_k8s_operator"></a> [enable\_spark\_k8s\_operator](#input\_enable\_spark\_k8s\_operator) | Enable Spark on K8s Operator add-on | `bool` | `false` | no |
@@ -135,6 +138,8 @@ No resources.
 | <a name="input_kube_state_metrics_helm_config"></a> [kube\_state\_metrics\_helm\_config](#input\_kube\_state\_metrics\_helm\_config) | Kube State Metrics Helm Chart config | `any` | `null` | no |
 | <a name="input_kube_state_metrics_irsa_permissions_boundary"></a> [kube\_state\_metrics\_irsa\_permissions\_boundary](#input\_kube\_state\_metrics\_irsa\_permissions\_boundary) | IAM Policy ARN for IRSA IAM role permissions boundary | `string` | `""` | no |
 | <a name="input_kube_state_metrics_irsa_policies"></a> [kube\_state\_metrics\_irsa\_policies](#input\_kube\_state\_metrics\_irsa\_policies) | IAM policy ARNs for Kube State Metrics IRSA | `list(string)` | `[]` | no |
+| <a name="input_kubernetes_dashboard_helm_config"></a> [kubernetes\_dashboard\_helm\_config](#input\_kubernetes\_dashboard\_helm\_config) | Kubernetes Dashboard Helm Chart config | `any` | `null` | no |
+| <a name="input_kubernetes_dashboard_irsa_policies"></a> [kubernetes\_dashboard\_irsa\_policies](#input\_kubernetes\_dashboard\_irsa\_policies) | IAM policy ARNs for Kubernetes Dashboard IRSA | `list(string)` | `[]` | no |
 | <a name="input_metrics_server_helm_config"></a> [metrics\_server\_helm\_config](#input\_metrics\_server\_helm\_config) | Metrics Server Helm Chart config | `any` | `{}` | no |
 | <a name="input_nginx_ingress_controller_irsa_permissions_boundary"></a> [nginx\_ingress\_controller\_irsa\_permissions\_boundary](#input\_nginx\_ingress\_controller\_irsa\_permissions\_boundary) | IAM Policy ARN for IRSA IAM role permissions boundary | `string` | `""` | no |
 | <a name="input_nginx_irsa_policies"></a> [nginx\_irsa\_policies](#input\_nginx\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
@@ -149,5 +154,4 @@ No resources.
 ## Outputs
 
 No outputs.
-
 <!--- END_TF_DOCS --->

--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -70,7 +70,6 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_Kubernetes_dashboard_irsa_permissions_boundary"></a> [Kubernetes\_dashboard\_irsa\_permissions\_boundary](#input\_Kubernetes\_dashboard\_irsa\_permissions\_boundary) | IAM Policy ARN for IRSA IAM role permissions boundary | `string` | `""` | no |
 | <a name="input_agones_helm_config"></a> [agones\_helm\_config](#input\_agones\_helm\_config) | Agones GameServer Helm Chart config | `any` | `{}` | no |
 | <a name="input_amazon_eks_aws_ebs_csi_driver_config"></a> [amazon\_eks\_aws\_ebs\_csi\_driver\_config](#input\_amazon\_eks\_aws\_ebs\_csi\_driver\_config) | configMap for AWS EBS CSI Driver add-on | `any` | `{}` | no |
 | <a name="input_amazon_eks_coredns_config"></a> [amazon\_eks\_coredns\_config](#input\_amazon\_eks\_coredns\_config) | ConfigMap for Amazon CoreDNS EKS add-on | `any` | `{}` | no |
@@ -139,6 +138,7 @@ No resources.
 | <a name="input_kube_state_metrics_irsa_permissions_boundary"></a> [kube\_state\_metrics\_irsa\_permissions\_boundary](#input\_kube\_state\_metrics\_irsa\_permissions\_boundary) | IAM Policy ARN for IRSA IAM role permissions boundary | `string` | `""` | no |
 | <a name="input_kube_state_metrics_irsa_policies"></a> [kube\_state\_metrics\_irsa\_policies](#input\_kube\_state\_metrics\_irsa\_policies) | IAM policy ARNs for Kube State Metrics IRSA | `list(string)` | `[]` | no |
 | <a name="input_kubernetes_dashboard_helm_config"></a> [kubernetes\_dashboard\_helm\_config](#input\_kubernetes\_dashboard\_helm\_config) | Kubernetes Dashboard Helm Chart config | `any` | `null` | no |
+| <a name="input_kubernetes_dashboard_irsa_permissions_boundary"></a> [kubernetes\_dashboard\_irsa\_permissions\_boundary](#input\_kubernetes\_dashboard\_irsa\_permissions\_boundary) | IAM Policy ARN for IRSA IAM role permissions boundary | `string` | `""` | no |
 | <a name="input_kubernetes_dashboard_irsa_policies"></a> [kubernetes\_dashboard\_irsa\_policies](#input\_kubernetes\_dashboard\_irsa\_policies) | IAM policy ARNs for Kubernetes Dashboard IRSA | `list(string)` | `[]` | no |
 | <a name="input_metrics_server_helm_config"></a> [metrics\_server\_helm\_config](#input\_metrics\_server\_helm\_config) | Metrics Server Helm Chart config | `any` | `{}` | no |
 | <a name="input_nginx_ingress_controller_irsa_permissions_boundary"></a> [nginx\_ingress\_controller\_irsa\_permissions\_boundary](#input\_nginx\_ingress\_controller\_irsa\_permissions\_boundary) | IAM Policy ARN for IRSA IAM role permissions boundary | `string` | `""` | no |

--- a/modules/kubernetes-addons/kubernetes-dashboard/README.md
+++ b/modules/kubernetes-addons/kubernetes-dashboard/README.md
@@ -1,0 +1,48 @@
+# Kubernetes Dashboard
+
+## Introduction
+
+[Kubernetes Dashboard](https://github.com/kubernetes/dashboard) is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage applications running in the cluster and troubleshoot them, as well as manage the cluster itself.
+
+This add-on bootstraps the Kubernetes Dashboard on the EKS cluster using a [helm chart](https://artifacthub.io/packages/helm/k8s-dashboard/kubernetes-dashboard) with the default configuration.
+
+<!--- BEGIN_TF_DOCS --->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_helm_addon"></a> [helm\_addon](#module\_helm\_addon) | ../helm-addon | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [kubectl_manifest.sa_config](https://registry.terraform.io/providers/hashicorp/kubectl/latest/docs/resources/manifest) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | EKS cluster Id | `string` | n/a | yes |
+| <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for the Kubernetes Dashboard | `any` | `{}` | no |
+| <a name="input_irsa_iam_permissions_boundary"></a> [irsa\_iam\_permissions\_boundary](#input\_irsa\_iam\_permissions\_boundary) | IAM Policy ARN for IRSA IAM role permissions boundary | `string` | `""` | no |
+| <a name="input_irsa_iam_policies"></a> [irsa\_iam\_policies](#input\_irsa\_iam\_policies) | IAM Policy ARN list for any IRSA policies | `list(string)` | `[]` | no |
+| <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps | `bool` | `false` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Common Tags for AWS resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_argocd_gitops_config"></a> [argocd\_gitops\_config](#output\_argocd\_gitops\_config) | Configuration used for managing the add-on with ArgoCD |
+<!--- END_TF_DOCS --->

--- a/modules/kubernetes-addons/kubernetes-dashboard/locals.tf
+++ b/modules/kubernetes-addons/kubernetes-dashboard/locals.tf
@@ -1,0 +1,52 @@
+locals {
+  name                 = "kubernetes-dashboard"
+  service_account_name = "eks-admin"
+  namespace            = "kube-system"
+  default_helm_config = {
+    name        = local.name
+    chart       = local.name
+    repository  = "https://kubernetes.github.io/dashboard/"
+    version     = "5.2.0"
+    namespace   = local.namespace
+    description = "Kubernetes Dashboard Helm Chart"
+    values      = local.default_helm_values
+    timeout     = "1200"
+  }
+
+  default_helm_values = [templatefile("${path.module}/values.yaml", {
+    sa-name = local.service_account_name
+  })]
+
+  helm_config = merge(
+    local.default_helm_config,
+    var.helm_config
+  )
+
+  set_values = [
+    {
+      name  = "serviceAccount.name"
+      value = local.service_account_name
+    },
+    {
+      name  = "serviceAccount.create"
+      value = false
+    }
+  ]
+
+  irsa_config = {
+    kubernetes_namespace              = local.name
+    kubernetes_service_account        = local.service_account_name
+    create_kubernetes_namespace       = false
+    create_kubernetes_service_account = true
+    iam_role_path                     = "/"
+    tags                              = var.tags
+    eks_cluster_id                    = var.eks_cluster_id
+    irsa_iam_policies                 = var.irsa_iam_policies
+    irsa_iam_permissions_boundary     = var.irsa_iam_permissions_boundary
+  }
+
+  argocd_gitops_config = {
+    enable             = true
+    serviceAccountName = local.service_account_name
+  }
+}

--- a/modules/kubernetes-addons/kubernetes-dashboard/main.tf
+++ b/modules/kubernetes-addons/kubernetes-dashboard/main.tf
@@ -1,0 +1,15 @@
+module "helm_addon" {
+  source            = "../helm-addon"
+  manage_via_gitops = var.manage_via_gitops
+  set_values        = local.set_values
+  helm_config       = local.helm_config
+  irsa_config       = local.irsa_config
+}
+
+resource "kubectl_manifest" "sa_config" {
+  yaml_body = templatefile("${path.module}/manifests/eks-admin-service-account.yaml", {
+    sa-name   = local.service_account_name
+    namespace = local.helm_config["namespace"]
+  })
+  depends_on = [module.helm_addon]
+}

--- a/modules/kubernetes-addons/kubernetes-dashboard/manifests/eks-admin-service-account.yaml
+++ b/modules/kubernetes-addons/kubernetes-dashboard/manifests/eks-admin-service-account.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: ${sa-name}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: ${sa-name}
+  namespace: ${namespace}

--- a/modules/kubernetes-addons/kubernetes-dashboard/outputs.tf
+++ b/modules/kubernetes-addons/kubernetes-dashboard/outputs.tf
@@ -1,0 +1,4 @@
+output "argocd_gitops_config" {
+  description = "Configuration used for managing the add-on with ArgoCD"
+  value       = var.manage_via_gitops ? local.argocd_gitops_config : null
+}

--- a/modules/kubernetes-addons/kubernetes-dashboard/values.yaml
+++ b/modules/kubernetes-addons/kubernetes-dashboard/values.yaml
@@ -1,0 +1,3 @@
+serviceAccount:
+  create: false
+  name: ${sa-name}

--- a/modules/kubernetes-addons/kubernetes-dashboard/variables.tf
+++ b/modules/kubernetes-addons/kubernetes-dashboard/variables.tf
@@ -1,0 +1,34 @@
+variable "helm_config" {
+  type        = any
+  description = "Helm provider config for the Kubernetes Dashboard"
+  default     = {}
+}
+
+variable "eks_cluster_id" {
+  type        = string
+  description = "EKS cluster Id"
+}
+
+variable "manage_via_gitops" {
+  type        = bool
+  default     = false
+  description = "Determines if the add-on should be managed via GitOps"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Common Tags for AWS resources"
+  default     = {}
+}
+
+variable "irsa_iam_policies" {
+  type        = list(string)
+  default     = []
+  description = "IAM Policy ARN list for any IRSA policies"
+}
+
+variable "irsa_iam_permissions_boundary" {
+  type        = string
+  default     = ""
+  description = "IAM Policy ARN for IRSA IAM role permissions boundary"
+}

--- a/modules/kubernetes-addons/locals.tf
+++ b/modules/kubernetes-addons/locals.tf
@@ -17,5 +17,6 @@ locals {
     argoRollouts              = var.enable_argo_rollouts ? module.argo_rollouts[0].argocd_gitops_config : null
     crossplane                = var.enable_crossplane ? module.crossplane[0].argocd_gitops_config : null
     kube_state_metrics        = var.enable_kube_state_metrics ? module.kube_state_metrics[0].argocd_gitops_config : null
+    kubernetes_dashboard      = var.enable_kubernetes_dashboard ? module.kubernetes_dashboard[0].argocd_gitops_config : null
   }
 }

--- a/modules/kubernetes-addons/locals.tf
+++ b/modules/kubernetes-addons/locals.tf
@@ -16,7 +16,7 @@ locals {
     yunikorn                  = var.enable_yunikorn ? module.yunikorn[0].argocd_gitops_config : null
     argoRollouts              = var.enable_argo_rollouts ? module.argo_rollouts[0].argocd_gitops_config : null
     crossplane                = var.enable_crossplane ? module.crossplane[0].argocd_gitops_config : null
-    kube_state_metrics        = var.enable_kube_state_metrics ? module.kube_state_metrics[0].argocd_gitops_config : null
-    kubernetes_dashboard      = var.enable_kubernetes_dashboard ? module.kubernetes_dashboard[0].argocd_gitops_config : null
+    kubeStateMetrics          = var.enable_kube_state_metrics ? module.kube_state_metrics[0].argocd_gitops_config : null
+    kubernetesDashboard       = var.enable_kubernetes_dashboard ? module.kubernetes_dashboard[0].argocd_gitops_config : null
   }
 }

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -235,3 +235,14 @@ module "kube_state_metrics" {
   tags                      = var.tags
   manage_via_gitops         = var.argocd_manage_add_ons
 }
+
+module "kubernetes_dashboard" {
+  count                     = var.enable_kubernetes_dashboard ? 1 : 0
+  source                    = "./kubernetes-dashboard"
+  eks_cluster_id            = var.eks_cluster_id
+  helm_config               = var.kubernetes_dashboard_helm_config
+  irsa_policies             = var.kubernetes_dashboard_irsa_policies
+  irsa_permissions_boundary = var.kubernetes_dashboard_irsa_permissions_boundary
+  tags                      = var.tags
+  manage_via_gitops         = var.argocd_manage_add_ons
+}

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -498,7 +498,7 @@ variable "kubernetes_dashboard_irsa_policies" {
   description = "IAM policy ARNs for Kubernetes Dashboard IRSA"
 }
 
-variable "Kubernetes_dashboard_irsa_permissions_boundary" {
+variable "kubernetes_dashboard_irsa_permissions_boundary" {
   type        = string
   default     = ""
   description = "IAM Policy ARN for IRSA IAM role permissions boundary"

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -478,3 +478,28 @@ variable "kube_state_metrics_irsa_permissions_boundary" {
   default     = ""
   description = "IAM Policy ARN for IRSA IAM role permissions boundary"
 }
+
+#-----------Kubernetes Dashboard ADDON-------------
+variable "enable_kubernetes_dashboard" {
+  type        = bool
+  default     = false
+  description = "Enable Kubernetes Dashboard add-on"
+}
+
+variable "kubernetes_dashboard_helm_config" {
+  type        = any
+  default     = null
+  description = "Kubernetes Dashboard Helm Chart config"
+}
+
+variable "kubernetes_dashboard_irsa_policies" {
+  type        = list(string)
+  default     = []
+  description = "IAM policy ARNs for Kubernetes Dashboard IRSA"
+}
+
+variable "Kubernetes_dashboard_irsa_permissions_boundary" {
+  type        = string
+  default     = ""
+  description = "IAM Policy ARN for IRSA IAM role permissions boundary"
+}


### PR DESCRIPTION
### What does this PR do?

Adds support for kubernetes-dashboard


### Motivation

Allows users to manage applications running in the cluster and troubleshoot them, as well as manage the cluster itself. 


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
