### PR TITLE
using data.aws_partition for identifying the current partition we are in

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "eks_key" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
       ]
     }
 
@@ -97,7 +97,7 @@ data "aws_iam_policy_document" "eks_key" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
       ]
     }
   }
@@ -113,7 +113,7 @@ data "aws_iam_policy_document" "eks_key" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.cluster_iam_role_name}",
+        "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/${local.cluster_iam_role_name}",
         data.aws_iam_session_context.current.issuer_arn
       ]
     }
@@ -134,7 +134,7 @@ data "aws_iam_policy_document" "eks_key" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.cluster_iam_role_name}"
+        "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/${local.cluster_iam_role_name}"
       ]
     }
   }
@@ -154,7 +154,7 @@ data "aws_iam_policy_document" "eks_key" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.cluster_iam_role_name}"
+        "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/${local.cluster_iam_role_name}"
       ]
     }
 

--- a/examples/crossplane/README.md
+++ b/examples/crossplane/README.md
@@ -196,6 +196,7 @@ terraform destroy --auto-approve
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_eks_cluster_auth.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs

--- a/examples/crossplane/main.tf
+++ b/examples/crossplane/main.tf
@@ -25,6 +25,8 @@ terraform {
   }
 }
 
+data "aws_partition" "current" {}
+
 data "aws_region" "current" {}
 
 data "aws_availability_zones" "available" {}
@@ -149,7 +151,7 @@ module "kubernetes-addons" {
     provider_aws_version = "v0.24.1"
     # NOTE: Crossplane requires Admin like permissions to create and update resources similar to Terraform deploy role.
     # This example config uses AmazonS3FullAccess for demo purpose only, but you should select a policy with the minimum permissions required to provision your resources.
-    additional_irsa_policies = ["arn:aws:iam::aws:policy/AmazonS3FullAccess"]
+    additional_irsa_policies = ["arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonS3FullAccess"]
   }
 
   # Creates ProviderConfig -> jet-aws-provider
@@ -158,6 +160,6 @@ module "kubernetes-addons" {
     provider_aws_version = "v0.4.1"
     # NOTE: Crossplane requires Admin like permissions to create and update resources similar to Terraform deploy role.
     # This example config uses AmazonS3FullAccess for demo purpose only, but you should select a policy with the minimum permissions required to provision your resources.
-    additional_irsa_policies = ["arn:aws:iam::aws:policy/AmazonS3FullAccess"]
+    additional_irsa_policies = ["arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonS3FullAccess"]
   }
 }

--- a/modules/aws-eks-fargate-profiles/iam.tf
+++ b/modules/aws-eks-fargate-profiles/iam.tf
@@ -6,7 +6,7 @@ resource "aws_iam_role" "fargate" {
 }
 
 resource "aws_iam_role_policy_attachment" "fargate_pod_execution_role_policy" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy"
   role       = aws_iam_role.fargate.name
 }
 

--- a/modules/aws-eks-managed-node-groups/locals.tf
+++ b/modules/aws-eks-managed-node-groups/locals.tf
@@ -49,7 +49,7 @@ locals {
     var.managed_ng
   )
 
-  policy_arn_prefix = "arn:aws:iam::aws:policy"
+  policy_arn_prefix = "arn:${data.aws_partition.current.partition}:iam::aws:policy"
   ec2_principal     = "ec2.${data.aws_partition.current.dns_suffix}"
 
   userdata_params = {

--- a/modules/aws-eks-self-managed-node-groups/locals.tf
+++ b/modules/aws-eks-self-managed-node-groups/locals.tf
@@ -50,7 +50,7 @@ locals {
   default_custom_ami_id = contains(local.predefined_ami_types, local.self_managed_node_group["launch_template_os"]) ? data.aws_ami.predefined[local.self_managed_node_group["launch_template_os"]].id : ""
   custom_ami_id         = local.self_managed_node_group["custom_ami_id"] == "" ? local.default_custom_ami_id : local.self_managed_node_group["custom_ami_id"]
 
-  policy_arn_prefix = "arn:aws:iam::aws:policy"
+  policy_arn_prefix = "arn:${data.aws_partition.current.partition}:iam::aws:policy"
   ec2_principal     = "ec2.${data.aws_partition.current.dns_suffix}"
 
   # EKS Worker Managed Policies

--- a/modules/kubernetes-addons/aws-ebs-csi-driver/README.md
+++ b/modules/kubernetes-addons/aws-ebs-csi-driver/README.md
@@ -43,6 +43,7 @@ No requirements.
 | [aws_eks_addon.aws_ebs_csi_driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_iam_policy.aws_ebs_csi_driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy_document.aws-ebs-csi-driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/modules/kubernetes-addons/aws-ebs-csi-driver/data.tf
+++ b/modules/kubernetes-addons/aws-ebs-csi-driver/data.tf
@@ -1,3 +1,5 @@
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "aws-ebs-csi-driver" {
   statement {
     sid       = ""
@@ -23,8 +25,8 @@ data "aws_iam_policy_document" "aws-ebs-csi-driver" {
     effect = "Allow"
 
     resources = [
-      "arn:aws:ec2:*:*:volume/*",
-      "arn:aws:ec2:*:*:snapshot/*",
+      "arn:${data.aws_partition.current.partition}:ec2:*:*:volume/*",
+      "arn:${data.aws_partition.current.partition}:ec2:*:*:snapshot/*",
     ]
 
     actions = ["ec2:CreateTags"]
@@ -45,8 +47,8 @@ data "aws_iam_policy_document" "aws-ebs-csi-driver" {
     effect = "Allow"
 
     resources = [
-      "arn:aws:ec2:*:*:volume/*",
-      "arn:aws:ec2:*:*:snapshot/*",
+      "arn:${data.aws_partition.current.partition}:ec2:*:*:volume/*",
+      "arn:${data.aws_partition.current.partition}:ec2:*:*:snapshot/*",
     ]
 
     actions = ["ec2:DeleteTags"]

--- a/modules/kubernetes-addons/aws-for-fluentbit/README.md
+++ b/modules/kubernetes-addons/aws-for-fluentbit/README.md
@@ -36,6 +36,7 @@ No requirements.
 | [aws_iam_policy_document.irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_session_context.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_session_context) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs

--- a/modules/kubernetes-addons/aws-for-fluentbit/data.tf
+++ b/modules/kubernetes-addons/aws-for-fluentbit/data.tf
@@ -1,5 +1,7 @@
 data "aws_region" "current" {}
 
+data "aws_partition" "current" {}
+
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_session_context" "current" {
@@ -10,14 +12,14 @@ data "aws_iam_policy_document" "irsa" {
   statement {
     sid       = "PutLogEvents"
     effect    = "Allow"
-    resources = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:*:log-stream:*"]
+    resources = ["arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:*:log-stream:*"]
     actions   = ["logs:PutLogEvents"]
   }
 
   statement {
     sid       = "CreateCWLogs"
     effect    = "Allow"
-    resources = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:*"]
+    resources = ["arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:*"]
 
     actions = [
       "logs:CreateLogStream",
@@ -37,7 +39,7 @@ data "aws_iam_policy_document" "kms" {
 
     principals {
       type = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root",
       data.aws_iam_session_context.current.issuer_arn]
     }
   }
@@ -58,7 +60,7 @@ data "aws_iam_policy_document" "kms" {
     condition {
       test     = "ArnEquals"
       variable = "kms:EncryptionContext:aws:logs:arn"
-      values   = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${local.log_group_name}"]
+      values   = ["arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${local.log_group_name}"]
     }
 
     principals {

--- a/modules/kubernetes-addons/aws-load-balancer-controller/README.md
+++ b/modules/kubernetes-addons/aws-load-balancer-controller/README.md
@@ -98,6 +98,7 @@ No requirements.
 | [aws_iam_policy.aws_load_balancer_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [helm_release.lb_ingress](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [aws_iam_policy_document.aws_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs

--- a/modules/kubernetes-addons/aws-load-balancer-controller/data.tf
+++ b/modules/kubernetes-addons/aws-load-balancer-controller/data.tf
@@ -1,5 +1,7 @@
 data "aws_region" "current" {}
 
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "aws_lb" {
   statement {
     sid       = ""
@@ -80,7 +82,7 @@ data "aws_iam_policy_document" "aws_lb" {
   statement {
     sid       = ""
     effect    = "Allow"
-    resources = ["arn:aws:ec2:*:*:security-group/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:ec2:*:*:security-group/*"]
     actions   = ["ec2:CreateTags"]
 
     condition {
@@ -99,7 +101,7 @@ data "aws_iam_policy_document" "aws_lb" {
   statement {
     sid       = ""
     effect    = "Allow"
-    resources = ["arn:aws:ec2:*:*:security-group/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:ec2:*:*:security-group/*"]
 
     actions = [
       "ec2:CreateTags",
@@ -118,9 +120,9 @@ data "aws_iam_policy_document" "aws_lb" {
     effect = "Allow"
 
     resources = [
-      "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-      "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-      "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*",
+      "arn:${data.aws_partition.current.partition}:elasticloadbalancing:*:*:targetgroup/*/*",
+      "arn:${data.aws_partition.current.partition}:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+      "arn:${data.aws_partition.current.partition}:elasticloadbalancing:*:*:loadbalancer/app/*/*",
     ]
 
     actions = [
@@ -139,7 +141,7 @@ data "aws_iam_policy_document" "aws_lb" {
   statement {
     sid       = ""
     effect    = "Allow"
-    resources = ["arn:aws:ec2:*:*:security-group/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:ec2:*:*:security-group/*"]
 
     actions = [
       "ec2:CreateTags",
@@ -212,9 +214,9 @@ data "aws_iam_policy_document" "aws_lb" {
     effect = "Allow"
 
     resources = [
-      "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-      "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-      "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*",
+      "arn:${data.aws_partition.current.partition}:elasticloadbalancing:*:*:targetgroup/*/*",
+      "arn:${data.aws_partition.current.partition}:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+      "arn:${data.aws_partition.current.partition}:elasticloadbalancing:*:*:loadbalancer/app/*/*",
     ]
 
     actions = [
@@ -261,7 +263,7 @@ data "aws_iam_policy_document" "aws_lb" {
   statement {
     sid       = ""
     effect    = "Allow"
-    resources = ["arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:elasticloadbalancing:*:*:targetgroup/*/*"]
 
     actions = [
       "elasticloadbalancing:RegisterTargets",

--- a/modules/kubernetes-addons/aws-vpc-cni/README.md
+++ b/modules/kubernetes-addons/aws-vpc-cni/README.md
@@ -40,6 +40,7 @@ No requirements.
 | Name | Type |
 |------|------|
 | [aws_eks_addon.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/modules/kubernetes-addons/aws-vpc-cni/data.tf
+++ b/modules/kubernetes-addons/aws-vpc-cni/data.tf
@@ -1,0 +1,1 @@
+data "aws_partition" "current" {}

--- a/modules/kubernetes-addons/aws-vpc-cni/main.tf
+++ b/modules/kubernetes-addons/aws-vpc-cni/main.tf
@@ -37,6 +37,6 @@ module "irsa_addon" {
   create_kubernetes_service_account = false
   kubernetes_namespace              = local.add_on_config["namespace"]
   kubernetes_service_account        = local.add_on_config["service_account"]
-  irsa_iam_policies                 = concat(["arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"], local.add_on_config["additional_iam_policies"])
+  irsa_iam_policies                 = concat(["arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKS_CNI_Policy"], local.add_on_config["additional_iam_policies"])
   tags                              = var.common_tags
 }

--- a/modules/kubernetes-addons/crossplane/README.md
+++ b/modules/kubernetes-addons/crossplane/README.md
@@ -61,6 +61,7 @@ ___
 | [kubectl_manifest.jet_aws_provider_config](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubernetes_namespace_v1.crossplane](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
 | [aws_iam_policy_document.s3_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/modules/kubernetes-addons/crossplane/data.tf
+++ b/modules/kubernetes-addons/crossplane/data.tf
@@ -1,8 +1,10 @@
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "s3_policy" {
   statement {
     sid       = "VisualEditor0"
     effect    = "Allow"
-    resources = ["arn:aws:s3:::*"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::*"]
 
     actions = [
       "s3:Get*",

--- a/modules/kubernetes-addons/ingress-nginx/README.md
+++ b/modules/kubernetes-addons/ingress-nginx/README.md
@@ -47,6 +47,7 @@ No requirements.
 | [aws_iam_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs

--- a/modules/kubernetes-addons/ingress-nginx/data.tf
+++ b/modules/kubernetes-addons/ingress-nginx/data.tf
@@ -1,5 +1,7 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_partition" "current" {}
+
 data "aws_region" "current" {}
 
 data "aws_iam_policy_document" "this" {
@@ -54,9 +56,9 @@ data "aws_iam_policy_document" "this" {
     effect = "Allow"
 
     resources = [
-      "arn:aws:elasticloadbalancing:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:targetgroup/*/*",
-      "arn:aws:elasticloadbalancing:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:loadbalancer/net/*/*",
-      "arn:aws:elasticloadbalancing:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:loadbalancer/app/*/*"
+      "arn:${data.aws_partition.current.partition}:elasticloadbalancing:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:targetgroup/*/*",
+      "arn:${data.aws_partition.current.partition}:elasticloadbalancing:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:loadbalancer/net/*/*",
+      "arn:${data.aws_partition.current.partition}:elasticloadbalancing:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:loadbalancer/app/*/*"
     ]
 
     actions = [
@@ -77,9 +79,9 @@ data "aws_iam_policy_document" "this" {
     effect = "Allow"
 
     resources = [
-      "arn:aws:elasticloadbalancing:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:targetgroup/*/*",
-      "arn:aws:elasticloadbalancing:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:loadbalancer/net/*/*",
-      "arn:aws:elasticloadbalancing:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:loadbalancer/app/*/*"
+      "arn:${data.aws_partition.current.partition}:elasticloadbalancing:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:targetgroup/*/*",
+      "arn:${data.aws_partition.current.partition}:elasticloadbalancing:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:loadbalancer/net/*/*",
+      "arn:${data.aws_partition.current.partition}:elasticloadbalancing:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:loadbalancer/app/*/*"
     ]
 
     actions = [

--- a/modules/kubernetes-addons/keda/README.md
+++ b/modules/kubernetes-addons/keda/README.md
@@ -58,6 +58,7 @@ No requirements.
 | [helm_release.keda](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.keda_irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/modules/kubernetes-addons/keda/data.tf
+++ b/modules/kubernetes-addons/keda/data.tf
@@ -1,12 +1,14 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "keda_irsa" {
   statement {
     effect = "Allow"
 
     resources = [
-      "arn:aws:cloudwatch:*:${data.aws_caller_identity.current.account_id}:metric-stream/*",
-      "arn:aws:sqs:*:${data.aws_caller_identity.current.account_id}:*",
+      "arn:${data.aws_partition.current.partition}:cloudwatch:*:${data.aws_caller_identity.current.account_id}:metric-stream/*",
+      "arn:${data.aws_partition.current.partition}:sqs:*:${data.aws_caller_identity.current.account_id}:*",
     ]
 
     actions = [


### PR DESCRIPTION
### What does this PR do?

Fixes #299 


### Motivation

We should support AWS partitions like `aws-us-gov` and `aws-cn`.


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
