### PR TITLE
Fix keda role path

### DIFF
--- a/modules/kubernetes-addons/keda/locals.tf
+++ b/modules/kubernetes-addons/keda/locals.tf
@@ -33,7 +33,7 @@ locals {
   ]
 
   irsa_config = {
-    kubernetes_namespace              = local.name
+    kubernetes_namespace              = local.helm_config["namespace"]
     kubernetes_service_account        = local.service_account_name
     create_kubernetes_namespace       = true
     create_kubernetes_service_account = true
@@ -41,6 +41,7 @@ locals {
     irsa_iam_permissions_boundary     = var.irsa_permissions_boundary
     eks_cluster_id                    = var.addon_context.eks_cluster_id
     iam_role_path                     = var.iam_role_path
+    eks_cluster_id                    = var.addon_context.eks_cluster_id
   }
 
   argocd_gitops_config = {

--- a/modules/kubernetes-addons/keda/locals.tf
+++ b/modules/kubernetes-addons/keda/locals.tf
@@ -40,6 +40,7 @@ locals {
     irsa_iam_policies                 = concat([aws_iam_policy.keda_irsa[0].arn], var.irsa_policies)
     irsa_iam_permissions_boundary     = var.irsa_permissions_boundary
     eks_cluster_id                    = var.addon_context.eks_cluster_id
+    iam_role_path                     = var.iam_role_path
   }
 
   argocd_gitops_config = {

--- a/modules/kubernetes-addons/keda/locals.tf
+++ b/modules/kubernetes-addons/keda/locals.tf
@@ -40,8 +40,6 @@ locals {
     irsa_iam_policies                 = concat([aws_iam_policy.keda_irsa[0].arn], var.irsa_policies)
     irsa_iam_permissions_boundary     = var.irsa_permissions_boundary
     eks_cluster_id                    = var.addon_context.eks_cluster_id
-    iam_role_path                     = var.iam_role_path
-    eks_cluster_id                    = var.addon_context.eks_cluster_id
   }
 
   argocd_gitops_config = {

--- a/modules/kubernetes-addons/keda/variables.tf
+++ b/modules/kubernetes-addons/keda/variables.tf
@@ -10,6 +10,12 @@ variable "manage_via_gitops" {
   description = "Determines if the add-on should be managed via GitOps"
 }
 
+variable "iam_role_path" {
+  type        = string
+  default     = "/"
+  description = "IAM role path"
+}
+
 variable "create_irsa" {
   type        = bool
   description = "Indicates if the add-on should create a IAM role + service account"

--- a/modules/kubernetes-addons/keda/variables.tf
+++ b/modules/kubernetes-addons/keda/variables.tf
@@ -10,12 +10,6 @@ variable "manage_via_gitops" {
   description = "Determines if the add-on should be managed via GitOps"
 }
 
-variable "iam_role_path" {
-  type        = string
-  default     = "/"
-  description = "IAM role path"
-}
-
 variable "create_irsa" {
   type        = bool
   description = "Indicates if the add-on should create a IAM role + service account"


### PR DESCRIPTION
The missing IAM role path is causing a plan with this module to fail.
This value is accepted by the IRSA module, so reinstate it and pass to
the module via the IRSA configuration.


### What does this PR do?

PR #312 introduced a breaking change. Remove of the `iam_role_path` prevents `terraform plan` from succeeding. Instead it fails with:

```
│ Error: Reference to undeclared input variable
│ 
│   on .terraform/modules/kubernetes-addons/keda/main.tf line 15, in resource "aws_iam_policy" "keda_irsa":
│   15:   path        = var.iam_role_path
│ 
│ An input variable with the name "iam_role_path" has not been declared. This
│ variable can be declared with a variable "iam_role_path" {} block.
╵
```
This change reintroduces that configuration parameter. It appears that it is supported as a configuration option by the IRSA module. This change also populates the IRSA module configuration with the value supplied. This enables the IRSA and associated IAM resources to be created under a particular path.

There were another couple of issues, so I aligned the code with what appears to be working under the `kubernetes_addons/vpa` module.

### Motivation

Breakage is blocking my current deployments.


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
