### PR TITLE
Refactoring cert-manager to leverage helm_addon module

### DIFF
--- a/modules/kubernetes-addons/cert-manager/README.md
+++ b/modules/kubernetes-addons/cert-manager/README.md
@@ -47,19 +47,21 @@ No requirements.
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_helm_addon"></a> [helm\_addon](#module\_helm\_addon) | ../helm-addon | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [helm_release.cert_manager](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.cert_manager_ca](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>  })</pre> | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Cert Manager Helm chart configuration | `any` | `{}` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
 

--- a/modules/kubernetes-addons/cert-manager/locals.tf
+++ b/modules/kubernetes-addons/cert-manager/locals.tf
@@ -13,8 +13,8 @@ locals {
     values      = local.default_helm_values
     timeout     = "600"
   }
-	
-	default_helm_values = [templatefile("${path.module}/values.yaml", {})]
+
+  default_helm_values = [templatefile("${path.module}/values.yaml", {})]
 
   helm_config = merge(
     local.default_helm_config,

--- a/modules/kubernetes-addons/cert-manager/locals.tf
+++ b/modules/kubernetes-addons/cert-manager/locals.tf
@@ -1,55 +1,46 @@
 
 locals {
-  default_helm_values = [templatefile("${path.module}/values.yaml", {})]
+  name                 = "cert-manager"
+  service_account_name = "${local.name}-sa"
 
   default_helm_config = {
-    name                       = "cert-manager"
-    chart                      = "cert-manager"
-    repository                 = "https://charts.jetstack.io"
-    version                    = "v1.6.1"
-    namespace                  = "kube-system"
-    timeout                    = "600"
-    create_namespace           = false
-    set                        = []
-    set_sensitive              = null
-    lint                       = false
-    values                     = local.default_helm_values
-    wait                       = true
-    wait_for_jobs              = false
-    description                = "Cert Manager Helm chart deployment configuration"
-    verify                     = false
-    keyring                    = ""
-    repository_key_file        = ""
-    repository_cert_file       = ""
-    repository_ca_file         = ""
-    repository_username        = ""
-    repository_password        = ""
-    disable_webhooks           = false
-    reuse_values               = false
-    reset_values               = false
-    force_update               = false
-    recreate_pods              = false
-    cleanup_on_fail            = false
-    max_history                = 0
-    atomic                     = false
-    skip_crds                  = false
-    render_subchart_notes      = true
-    disable_openapi_validation = false
-    dependency_update          = false
-    replace                    = false
-    postrender                 = ""
-
-    # Install a CA issuer with a helper chart
-    # See ./cert-manager-ca/templates/ca.yaml
-    install_default_ca = var.manage_via_gitops ? false : true
+    name        = local.name
+    chart       = local.name
+    repository  = "https://charts.jetstack.io"
+    version     = "v1.7.1"
+    namespace   = local.name
+    description = "Argo Rollouts AddOn Helm Chart"
+    values      = local.default_helm_values
+    timeout     = "600"
   }
+	
+	default_helm_values = [templatefile("${path.module}/values.yaml", {})]
 
   helm_config = merge(
     local.default_helm_config,
     var.helm_config
   )
 
+  set_values = [
+    {
+      name  = "serviceAccount.name"
+      value = local.service_account_name
+    },
+    {
+      name  = "serviceAccount.create"
+      value = false
+    }
+  ]
+
+  irsa_config = {
+    kubernetes_namespace              = local.helm_config["namespace"]
+    kubernetes_service_account        = local.service_account_name
+    create_kubernetes_namespace       = true
+    create_kubernetes_service_account = true
+  }
+
   argocd_gitops_config = {
-    enable = true
+    enable             = true
+    serviceAccountName = local.service_account_name
   }
 }

--- a/modules/kubernetes-addons/cert-manager/main.tf
+++ b/modules/kubernetes-addons/cert-manager/main.tf
@@ -16,72 +16,21 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-resource "helm_release" "cert_manager" {
-  count                      = var.manage_via_gitops ? 0 : 1
-  name                       = local.helm_config["name"]
-  repository                 = local.helm_config["repository"]
-  chart                      = local.helm_config["chart"]
-  version                    = local.helm_config["version"]
-  namespace                  = local.helm_config["namespace"]
-  timeout                    = local.helm_config["timeout"]
-  values                     = local.helm_config["values"]
-  create_namespace           = local.helm_config["create_namespace"]
-  lint                       = local.helm_config["lint"]
-  description                = local.helm_config["description"]
-  repository_key_file        = local.helm_config["repository_key_file"]
-  repository_cert_file       = local.helm_config["repository_cert_file"]
-  repository_ca_file         = local.helm_config["repository_ca_file"]
-  repository_username        = local.helm_config["repository_username"]
-  repository_password        = local.helm_config["repository_password"]
-  verify                     = local.helm_config["verify"]
-  keyring                    = local.helm_config["keyring"]
-  disable_webhooks           = local.helm_config["disable_webhooks"]
-  reuse_values               = local.helm_config["reuse_values"]
-  reset_values               = local.helm_config["reset_values"]
-  force_update               = local.helm_config["force_update"]
-  recreate_pods              = local.helm_config["recreate_pods"]
-  cleanup_on_fail            = local.helm_config["cleanup_on_fail"]
-  max_history                = local.helm_config["max_history"]
-  atomic                     = local.helm_config["atomic"]
-  skip_crds                  = local.helm_config["skip_crds"]
-  render_subchart_notes      = local.helm_config["render_subchart_notes"]
-  disable_openapi_validation = local.helm_config["disable_openapi_validation"]
-  wait                       = local.helm_config["wait"]
-  wait_for_jobs              = local.helm_config["wait_for_jobs"]
-  dependency_update          = local.helm_config["dependency_update"]
-  replace                    = local.helm_config["replace"]
-
-  postrender {
-    binary_path = local.helm_config["postrender"]
-  }
-
-  dynamic "set" {
-    iterator = each_item
-    for_each = local.helm_config["set"] == null ? [] : local.helm_config["set"]
-
-    content {
-      name  = each_item.value.name
-      value = each_item.value.value
-    }
-  }
-
-  dynamic "set_sensitive" {
-    iterator = each_item
-    for_each = local.helm_config["set_sensitive"] == null ? [] : local.helm_config["set_sensitive"]
-
-    content {
-      name  = each_item.value.name
-      value = each_item.value.value
-    }
-  }
+module "helm_addon" {
+  source            = "../helm-addon"
+  manage_via_gitops = var.manage_via_gitops
+  set_values        = local.set_values
+  helm_config       = local.helm_config
+  irsa_config       = local.irsa_config
+  addon_context     = var.addon_context
 }
 
 resource "helm_release" "cert_manager_ca" {
-  count     = local.helm_config["install_default_ca"] ? 1 : 0
+  count     = var.manage_via_gitops ? 0 : 1
   name      = "cert-manager-ca"
   chart     = "${path.module}/cert-manager-ca"
   version   = "0.2.0"
-  namespace = "kube-system"
+  namespace = local.helm_config["namespace"]
 
-  depends_on = [helm_release.cert_manager]
+  depends_on = [module.helm_addon]
 }

--- a/modules/kubernetes-addons/cert-manager/variables.tf
+++ b/modules/kubernetes-addons/cert-manager/variables.tf
@@ -27,3 +27,18 @@ variable "manage_via_gitops" {
   default     = false
   description = "Determines if the add-on should be managed via GitOps."
 }
+
+variable "addon_context" {
+  type = object({
+    aws_caller_identity_account_id = string
+    aws_caller_identity_arn        = string
+    aws_eks_cluster_endpoint       = string
+    aws_partition_id               = string
+    aws_region_name                = string
+    eks_cluster_id                 = string
+    eks_oidc_issuer_url            = string
+    eks_oidc_provider_arn          = string
+    tags                           = map(string)
+  })
+  description = "Input configuration for the addon"
+}

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -117,6 +117,7 @@ module "cert_manager" {
   source            = "./cert-manager"
   helm_config       = var.cert_manager_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
+  addon_context     = local.addon_context
 }
 
 module "cluster_autoscaler" {


### PR DESCRIPTION
### What does this PR do?

* Refactors `cert-manager` add-on to leverage the `helm_addon` submodule. 
* Bumps `cert-manager` version to `v1.7.1`
* Changes `cert-manager` from namespace `kube-system` to `cert-manager` per `cert-manager` docs.
* Removes boilerplate.

### Motivation

Removing unneeded boilerplate code.

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
