### PR TITLE
fix: set fail-fast to false GH matrix

### DIFF
--- a/.github/workflows/e2e-all-tests-parallel.yml
+++ b/.github/workflows/e2e-all-tests-parallel.yml
@@ -18,6 +18,7 @@ jobs:
       id-token: write
       contents: read
     strategy:
+      fail-fast: false
       matrix:
         tf_working_dir:
           [


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
