### PR TITLE
fix: fix example - ami type string

### DIFF
--- a/examples/managed-node-groups/main.tf
+++ b/examples/managed-node-groups/main.tf
@@ -307,7 +307,7 @@ module "aws-eks-accelerator-for-terraform" {
       max_unavailable = 1 # or percentage = 20
 
       # 3> Node Group compute configuration
-      ami_type       = "AL2_ARM_64" # AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64, CUSTOM, BOTTLEROCKET_ARM_64, BOTTLEROCKET_X86_64
+      ami_type       = "AL2_ARM_64" # AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64, CUSTOM, BOTTLEROCKET_ARM_64, BOTTLEROCKET_x86_64
       capacity_type  = "ON_DEMAND"  # ON_DEMAND or SPOT
       instance_types = ["m5.large"] # List of instances used only for SPOT type
       disk_size      = 50
@@ -349,7 +349,7 @@ module "aws-eks-accelerator-for-terraform" {
       max_unavailable = 1 # or percentage = 20
 
       # 3> Node Group compute configuration
-      ami_type       = "BOTTLEROCKET_ARM_64" # AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64, CUSTOM, BOTTLEROCKET_ARM_64, BOTTLEROCKET_X86_64
+      ami_type       = "BOTTLEROCKET_ARM_64" # AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64, CUSTOM, BOTTLEROCKET_ARM_64, BOTTLEROCKET_x86_64
       capacity_type  = "ON_DEMAND"           # ON_DEMAND or SPOT
       instance_types = ["m5.large"]          # List of instances used only for SPOT type
       disk_size      = 50

--- a/examples/managed-node-groups/main.tf
+++ b/examples/managed-node-groups/main.tf
@@ -391,7 +391,7 @@ module "aws-eks-accelerator-for-terraform" {
       max_unavailable = 1 # or percentage = 20
 
       # 3> Node Group compute configuration
-      ami_type       = "BOTTLEROCKET_X86_64" # AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64, CUSTOM, BOTTLEROCKET_ARM_64, BOTTLEROCKET_X86_64
+      ami_type       = "BOTTLEROCKET_x86_64" # AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64, CUSTOM, BOTTLEROCKET_ARM_64, BOTTLEROCKET_x86_64
       capacity_type  = "ON_DEMAND"           # ON_DEMAND or SPOT
       instance_types = ["m5.large"]          # List of instances used only for SPOT type
       disk_size      = 50


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- fixing managed node group example - bottlerocket ami string was incorrect, needs to be lower case `x`

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
