### PR TITLE
fix: windows-node-group to use us-west-2 region

### DIFF
--- a/examples/windows-node-groups/README.md
+++ b/examples/windows-node-groups/README.md
@@ -32,11 +32,11 @@ terraform init
 to verify the resources created by this execution
 
 ```bash
-export AWS_REGION=us-east-1   # Select your own region
+export AWS_REGION=us-west-2   # Select your own region
 terraform plan
 ```
 
-If you want to use a region other than `us-east-1`, update the `aws_region` name and `aws_availability_zones` filter in the data sources in [main.tf](./main.tf) accordingly.
+If you want to use a region other than `us-west-2`, update the `aws_region` name and `aws_availability_zones` filter in the data sources in [main.tf](./main.tf) accordingly.
 
 ### Step4: Run `terraform apply`
 to create resources
@@ -52,7 +52,7 @@ EKS Cluster details can be extracted from terraform output or from AWS Console t
 
 `~/.kube/config` file gets updated with EKS cluster context from the below command. Replace the region name and EKS cluster name with your cluster's name. (If you did not change the `tenant`, `environment`, and `zone` values in this example, the EKS cluster name will be `aws001-preprod-dev-eks`.)
 
-    $ aws eks --region us-east-1 update-kubeconfig --name aws001-preprod-dev-eks
+    $ aws eks --region us-west-2 update-kubeconfig --name aws001-preprod-dev-eks
 
 ### Step6: (Optional) Deploy sample Windows and Linux workloads to verify support for both operating systems
 When Windows support is enabled in the cluster, it is necessary to use one of the ways to assign pods to specific nodes, such as `nodeSelector` or `affinity`. See the [K8s documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) for more info. This example uses `nodeSelector`s to select nodes with appropriate OS for pods.

--- a/examples/windows-node-groups/main.tf
+++ b/examples/windows-node-groups/main.tf
@@ -23,7 +23,7 @@ terraform {
 
 data "aws_region" "current" {
   # Change this per your need
-  name = "us-east-1"
+  name = "us-west-2"
 }
 
 data "aws_availability_zones" "available" {
@@ -33,7 +33,7 @@ data "aws_availability_zones" "available" {
   # https://aws.amazon.com/premiumsupport/knowledge-center/eks-cluster-creation-errors/
   filter {
     name   = "zone-name"
-    values = ["us-east-1a", "us-east-1b", "us-east-1c"]
+    values = ["us-west-2a", "us-west-2b", "us-west-2c"]
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- use `us-west-2` as the default region for windows-node-group example to align with other examples and allow run for e2e workflow testing
### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
