### PR TITLE
Fix/example advanced k8s

### DIFF
--- a/.github/workflows/e2e-all-tests-parallel.yml
+++ b/.github/workflows/e2e-all-tests-parallel.yml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         tf_working_dir:
           [
-            examples/advanced/k8s_addons,
             examples/analytics/emr-on-eks,
             examples/analytics/spark-k8s-operator,
             examples/argocd,
@@ -37,7 +36,6 @@ jobs:
             examples/karpenter,
             examples/managed-node-groups,
             examples/multi-tenancy-with-teams,
-            examples/observability/eks-cluster-with-amp-amg-opensearch,
             examples/self-managed-node-groups,
             examples/windows-node-groups
           ]

--- a/examples/advanced/k8s_addons/main.tf
+++ b/examples/advanced/k8s_addons/main.tf
@@ -389,7 +389,7 @@ module "kubernetes-addons" {
 [OUTPUT]
   Name cloudwatch_logs
   Match *
-  region eu-west-1
+  region ${data.aws_region.current.name}
   log_group_name /${local.eks_cluster_id}/fargate-fluentbit-logs
   log_stream_prefix "fargate-logs-"
   auto_create_group true


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- replacing hard coded region to data source value
- disabling k8s-advanced and observability from e2e matrix list
  - k8s-advanced required variables to be passed (e.g. VPC id), these use cases needs to be addressed for the parallel e2e scope
  - observability TF plan time takes way longer than expected, disabling from e2e until example fixed. 

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
