### PR TITLE
Add managed-node-groups-tfvars example

### DIFF
--- a/examples/managed-node-groups-tfvars/README.md
+++ b/examples/managed-node-groups-tfvars/README.md
@@ -1,0 +1,143 @@
+# EKS Cluster with Managed Node Group
+
+This example deploys a new EKS Cluster with a Managed node group into a new VPC.
+
+* Creates a new sample VPC, 3 Private Subnets and 3 Public Subnets
+* Creates an Internet gateway for the Public Subnets and a NAT Gateway for the
+  Private Subnets
+* Creates an EKS Cluster Control plane with Managed node groups
+
+## How to Deploy
+
+### Prerequisites
+
+Ensure that you have installed the following tools in your Mac or Windows Laptop
+before start working with this module and run Terraform Plan and Apply
+
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+* [Kubectl](https://Kubernetes.io/docs/tasks/tools/)
+* [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+
+### Deployment Steps
+
+#### Step1: Clone the repo using the command below
+
+```shell script
+git clone https://github.com/aws-samples/aws-eks-accelerator-for-terraform.git
+```
+
+#### Step2: Run Terraform INIT
+
+Initialize a working directory with configuration files
+
+```shell script
+cd examples/managed-node-groups-tfvars/
+terraform init
+```
+
+#### Step3: Run Terraform PLAN
+
+Verify the resources created by this execution
+
+```shell script
+export AWS_REGION=eu-central-1   # Select your own region
+terraform plan -var-file="variables.tfvars"
+```
+
+#### Step4: Finally, Terraform APPLY
+
+to create resources
+
+```shell script
+terraform apply
+```
+
+Enter `yes` to apply
+
+### Configure `kubectl` and test cluster
+
+EKS Cluster details can be extracted from terraform output or from AWS Console
+to get the name of cluster.
+This following command used to update the `kubeconfig` in your local machine
+where you run kubectl commands to interact with your EKS Cluster.
+
+#### Step5: Run `update-kubeconfig` command
+
+Get the list of your clusters
+
+```shell script
+aws eks --region "${AWS_REGION}" list-clusters
+```
+
+`~/.kube/config` file gets updated with cluster details and certificate from
+the below command
+
+```shell script
+aws eks --region "${AWS_REGION}" update-kubeconfig --name "aws-preprod-dev-eks"
+```
+
+#### Step6: List all the worker nodes by running the command below
+
+```shell script
+kubectl get nodes
+```
+
+#### Step7: List all the pods running in `kube-system` namespace
+
+```shell script
+kubectl get pods -n kube-system
+```
+
+## How to Destroy
+
+The following command destroys the resources created by `terraform apply`
+
+```shell script
+cd examples/managed-node-groups-tfvars
+terraform destroy --auto-approve
+```
+
+---
+
+<!--- BEGIN_TF_DOCS --->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.66.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.6.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.66.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_aws-eks-accelerator-for-terraform"></a> [aws-eks-accelerator-for-terraform](#module\_aws-eks-accelerator-for-terraform) | ../../ | n/a |
+| <a name="module_aws_vpc"></a> [aws\_vpc](#module\_aws\_vpc) | terraform-aws-modules/vpc/aws | v3.2.0 |
+| <a name="module_kubernetes-addons"></a> [kubernetes-addons](#module\_kubernetes-addons) | ../../modules/kubernetes-addons | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_eks_cluster_auth.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+
+<!--- END_TF_DOCS --->

--- a/examples/managed-node-groups-tfvars/data.tf
+++ b/examples/managed-node-groups-tfvars/data.tf
@@ -1,0 +1,14 @@
+#------------------------------------------------------------------------
+# Data Resources
+#------------------------------------------------------------------------
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "available" {}
+
+data "aws_eks_cluster" "cluster" {
+  name = module.aws-eks-accelerator-for-terraform.eks_cluster_id
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.aws-eks-accelerator-for-terraform.eks_cluster_id
+}

--- a/examples/managed-node-groups-tfvars/eks.tf
+++ b/examples/managed-node-groups-tfvars/eks.tf
@@ -1,0 +1,43 @@
+#------------------------------------------------------------------------
+# AWS VPC Module
+#------------------------------------------------------------------------
+module "aws_vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "v3.12.0"
+
+  name = local.vpc_name
+  cidr = var.vpc_cidr
+  azs  = data.aws_availability_zones.available.names
+
+  public_subnets  = [for k, v in slice(data.aws_availability_zones.available.names, 0, local.count_availability_zone) : cidrsubnet(var.vpc_cidr, 8, k)]
+  private_subnets = [for k, v in slice(data.aws_availability_zones.available.names, 0, local.count_availability_zone) : cidrsubnet(var.vpc_cidr, 8, k + 10)]
+
+  enable_nat_gateway   = true
+  enable_dns_hostnames = true
+  single_nat_gateway   = true
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                      = "1"
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"             = "1"
+  }
+}
+
+#------------------------------------------------------------------------
+# AWS EKS Accelerator Module
+#------------------------------------------------------------------------
+module "aws-eks-accelerator-for-terraform" {
+  # source = "github.com/aws-samples/aws-eks-accelerator-for-terraform?ref=v3.5.0"
+  source = "../../"
+
+  # EKS Cluster VPC and Subnet mandatory config
+  vpc_id             = module.aws_vpc.vpc_id
+  private_subnet_ids = module.aws_vpc.private_subnets
+
+  # EKS MANAGED NODE GROUPS with minimum config
+  managed_node_groups = var.managed_node_groups
+}

--- a/examples/managed-node-groups-tfvars/main.tf
+++ b/examples/managed-node-groups-tfvars/main.tf
@@ -1,0 +1,56 @@
+#------------------------------------------------------------------------
+# Terraform Provider Versions
+#------------------------------------------------------------------------
+terraform {
+  required_version = ">= 1.0.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.4.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.6.1"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.4.1"
+    }
+  }
+
+  backend "local" {
+    path = "local_tf_state/terraform-main.tfstate"
+  }
+}
+
+#------------------------------------------------------------------------
+# Terraform Providers
+#------------------------------------------------------------------------
+provider "aws" {}
+
+provider "kubernetes" {
+  experiments {
+    manifest_resource = true
+  }
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    token                  = data.aws_eks_cluster_auth.cluster.token
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  }
+}
+
+#------------------------------------------------------------------------
+# Local Variables
+#------------------------------------------------------------------------
+locals {
+  count_availability_zone = (length(data.aws_availability_zones.available.names) <= 3) ? length(data.aws_availability_zones.available.zone_ids) : 3
+  vpc_name                = join("-", [var.tenant, var.environment, var.zone, "vpc"])
+  cluster_name            = join("-", [var.tenant, var.environment, var.zone, "eks"])
+}

--- a/examples/managed-node-groups-tfvars/variables.tf
+++ b/examples/managed-node-groups-tfvars/variables.tf
@@ -1,0 +1,27 @@
+variable "environment" {
+  type        = string
+  default     = "preprod"
+  description = "Environment area, e.g. prod or preprod "
+}
+
+variable "managed_node_groups" {
+  type        = any
+  description = "A map of Managed node group(s)"
+}
+
+variable "vpc_cidr" {
+  description = "VPC CIDR"
+  type        = string
+}
+
+variable "tenant" {
+  type        = string
+  description = "Account Name or unique account unique id e.g., apps or management or aws007"
+  default     = "aws"
+}
+
+variable "zone" {
+  type        = string
+  description = "zone, e.g. dev or qa or load or ops etc..."
+  default     = "dev"
+}

--- a/examples/managed-node-groups-tfvars/variables.tfvars
+++ b/examples/managed-node-groups-tfvars/variables.tfvars
@@ -1,0 +1,17 @@
+managed_node_groups = {
+  eks-ng01 = {
+    node_group_name = "eks-ng01"
+
+    desired_size    = 2
+    min_size        = 2
+    max_size        = 3
+    max_unavailable = 1
+
+    ami_type       = "BOTTLEROCKET_x86_64"
+    capacity_type  = "ON_DEMAND"
+    instance_types = ["t2.medium"]
+    disk_size      = 20
+  }
+}
+
+vpc_cidr = "10.0.0.0/16"


### PR DESCRIPTION
### What does this PR do?

Adding example showing the usage of variable file as discussed in https://github.com/aws-samples/aws-eks-accelerator-for-terraform/issues/332.


### Motivation

It may be another handy example about using the module...

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR
