### PR TITLE
fix: honor variable `tag` to add custom tags

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -48,7 +48,12 @@ locals {
     tags             = module.eks_tags.tags
   }
 
-  tags = tomap({ "created-by" = var.terraform_version })
+  tags = merge(
+    var.tags,
+    {
+      "created-by" = var.terraform_version
+    },
+  )    
 
   ecr_image_repo_url = "${local.context.aws_caller_identity_account_id}.dkr.ecr.${local.context.aws_region_name}.amazonaws.com"
 


### PR DESCRIPTION
### What does this PR do?

You cannot pass custom tags to the EKS cluster:

```hcl
module "aws_eks" {
  tags = module.eks_tags.tags
}

module "eks_tags" {
  source      = "./modules/aws-resource-tags"
  tags        = local.tags
}

locals {
  tags = tomap({ "created-by" = var.terraform_version }) # reference to var.tags is missing here
}
``` 

### Motivation

Fixing the issue.

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
