### PR TITLE
Fix/remove depends on and input examples from gh e2e workflow

### DIFF
--- a/.github/workflows/examples-tfplan-tests.yml
+++ b/.github/workflows/examples-tfplan-tests.yml
@@ -36,9 +36,7 @@ jobs:
             examples/node-groups/managed-node-groups,
             examples/node-groups/self-managed-node-groups,
             examples/node-groups/windows-node-groups,
-            examples/node-groups/fargate-profiles,
-            examples/node-groups/managed-node-groups-tfvars,
-            examples/complete-kubernetes-addons
+            examples/node-groups/fargate-profiles
           ]
 
     steps:

--- a/examples/eks-cluster-with-new-vpc/main.tf
+++ b/examples/eks-cluster-with-new-vpc/main.tf
@@ -122,7 +122,6 @@ module "aws-eks-accelerator-for-terraform" {
       subnet_ids      = module.aws_vpc.private_subnets
     }
   }
-  depends_on = [module.aws_vpc]
 }
 
 module "kubernetes-addons" {


### PR DESCRIPTION
### What does this PR do?
- Remove examples that require input vars 
- Remove depends_on from new-vpc example
<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->
- with latest upgrade to upstream version, we can't use `depends_on` on main accelerator module due to changes with the upstream EKS module - [see here for more info](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/README.md#%E2%84%B9%EF%B8%8F-error-invalid-for_each-argument-)
- Remove examples that require input vars, currently GH e2e workflow does not support those examples.

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
