### PR TITLE
fix: remove incubator reference for yunikorn

### DIFF
--- a/docs/add-ons/yunikorn.md
+++ b/docs/add-ons/yunikorn.md
@@ -19,7 +19,7 @@ Alternatively, you can override the helm values by using the code snippet below
 
   yunikorn_helm_config = {
     name       = "yunikorn"                                 # (Required) Release name.
-    repository = "https://apache.github.io/incubator-yunikorn-release" # (Optional) Repository URL where to locate the requested chart.
+    repository = "https://apache.github.io/yunikorn-release" # (Optional) Repository URL where to locate the requested chart.
     chart      = "yunikorn"                                 # (Required) Chart name to be installed.
     version    = "0.12.2"                               # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config: https://github.com/aws-samples/aws-eks-accelerator-for-terraform/blob/main/modules/kubernetes-addons/yunikorn/locals.tf
     values     = [templatefile("${path.module}/values.yaml", {})]

--- a/examples/analytics/spark-k8s-operator/main.tf
+++ b/examples/analytics/spark-k8s-operator/main.tf
@@ -159,10 +159,10 @@ module "kubernetes-addons" {
   #---------------------------------------
   enable_yunikorn = true
   yunikorn_helm_config = {
-    name       = "yunikorn"                                            # (Required) Release name.
-    repository = "https://apache.github.io/incubator-yunikorn-release" # (Optional) Repository URL where to locate the requested chart.
-    chart      = "yunikorn"                                            # (Required) Chart name to be installed.
-    version    = "0.12.2"                                              # (Optional) Specify the exact chart version to install.
+    name       = "yunikorn"                                  # (Required) Release name.
+    repository = "https://apache.github.io/yunikorn-release" # (Optional) Repository URL where to locate the requested chart.
+    chart      = "yunikorn"                                  # (Required) Chart name to be installed.
+    version    = "0.12.2"                                    # (Optional) Specify the exact chart version to install.
     values     = [templatefile("${path.module}/helm_values/yunikorn-values.yaml", {})]
   }
 

--- a/examples/complete-kubernetes-addons/main.tf
+++ b/examples/complete-kubernetes-addons/main.tf
@@ -458,10 +458,10 @@ module "kubernetes-addons" {
   #---------------------------------------
   enable_yunikorn = true
   yunikorn_helm_config = {
-    name       = "yunikorn"                                            # (Required) Release name.
-    repository = "https://apache.github.io/incubator-yunikorn-release" # (Optional) Repository URL where to locate the requested chart.
-    chart      = "yunikorn"                                            # (Required) Chart name to be installed.
-    version    = "0.12.2"                                              # (Optional) Specify the exact chart version to install.
+    name       = "yunikorn"                                  # (Required) Release name.
+    repository = "https://apache.github.io/yunikorn-release" # (Optional) Repository URL where to locate the requested chart.
+    chart      = "yunikorn"                                  # (Required) Chart name to be installed.
+    version    = "0.12.2"                                    # (Optional) Specify the exact chart version to install.
     values     = [templatefile("${path.module}/helm_values/yunikorn-values.yaml", {})]
   }
 

--- a/modules/kubernetes-addons/yunikorn/locals.tf
+++ b/modules/kubernetes-addons/yunikorn/locals.tf
@@ -4,7 +4,7 @@ locals {
   default_helm_config = {
     name        = local.name
     chart       = local.name
-    repository  = "https://apache.github.io/incubator-yunikorn-release"
+    repository  = "https://apache.github.io/yunikorn-release"
     version     = "0.12.2"
     namespace   = local.name
     description = "Apache YuniKorn (Incubating) is a light-weight, universal resource scheduler for container orchestrator systems"


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Removes `incubator` reference for yunikorn project as they moved out of it 

### Motivation

<!-- What inspired you to submit this pull request? -->
https://github.com/aws-samples/aws-eks-accelerator-for-terraform/issues/368

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
