### PR TITLE
Agones example fix with correct namespace

### DIFF
--- a/docs/add-ons/agones.md
+++ b/docs/add-ons/agones.md
@@ -20,12 +20,12 @@ You can optionally customize the Helm chart that deploys `Agones` via the follow
   enable_agones = true
   # Optional  agones_helm_config
   agones_helm_config = {
-    name                       = "aws-load-balancer-controller"
-    chart                      = "aws-load-balancer-controller"
-    repository                 = "https://aws.github.io/eks-charts"
-    version                    = "1.3.1"
-    namespace                  = "kube-system"
-    values = [templatefile("${path.module}/values.yaml", {
+    name                       = "agones"
+    chart                      = "agones"
+    repository                 = "https://agones.dev/chart/stable"
+    version                    = "1.21.0"
+    namespace                  = "agones-system" # Agones recommends to install in it's own namespace such as `agones-system` as shown here. You can specify any namespace here other than `kube-system`
+    values = [templatefile("${path.module}/helm_values/agones-values.yaml", {
       expose_udp            = true
       gameserver_namespaces = "{${join(",", ["default", "xbox-gameservers", "xbox-gameservers"])}}"
       gameserver_minport    = 7000

--- a/docs/add-ons/agones.md
+++ b/docs/add-ons/agones.md
@@ -24,7 +24,7 @@ You can optionally customize the Helm chart that deploys `Agones` via the follow
     chart                      = "agones"
     repository                 = "https://agones.dev/chart/stable"
     version                    = "1.21.0"
-    namespace                  = "agones-system" # Agones recommends to install in it's own namespace such as `agones-system` as shown here. You can specify any namespace here other than `kube-system`
+    namespace                  = "agones-system" # Agones recommends to install in it's own namespace such as `agones-system` as shown here. You can specify any namespace other than `kube-system`
     values = [templatefile("${path.module}/helm_values/agones-values.yaml", {
       expose_udp            = true
       gameserver_namespaces = "{${join(",", ["default", "xbox-gameservers", "xbox-gameservers"])}}"

--- a/examples/game-tech/agones-game-controller/README.md
+++ b/examples/game-tech/agones-game-controller/README.md
@@ -67,9 +67,9 @@ This following command used to update the `kubeconfig` in your local machine whe
 
     $ kubectl get nodes
 
-#### Step7: List all the pods running in `kube-system` namespace
+#### Step7: List all the pods running in `agones-system` namespace
 
-    $ kubectl get pods -n kube-system
+    $ kubectl get pods -n agones-system
 
 ## Step8: Install K9s
 This step is to install K9s client tool to interact with EKS Cluster

--- a/examples/game-tech/agones-game-controller/main.tf
+++ b/examples/game-tech/agones-game-controller/main.tf
@@ -177,7 +177,7 @@ module "kubernetes-addons" {
     chart      = "agones"
     repository = "https://agones.dev/chart/stable"
     version    = "1.21.0"
-    namespace  = "agones-system" # Agones recommends to install in it's own namespace such as `agones-system` as shown here. You can specify any namespace here other than `kube-system`
+    namespace  = "agones-system" # Agones recommends to install in it's own namespace such as `agones-system` as shown here. You can specify any namespace other than `kube-system`
     values = [templatefile("${path.module}/helm_values/agones-values.yaml", {
       expose_udp            = true
       gameserver_namespaces = "{${join(",", ["default", "xbox-gameservers", "xbox-gameservers"])}}"

--- a/examples/game-tech/agones-game-controller/main.tf
+++ b/examples/game-tech/agones-game-controller/main.tf
@@ -173,13 +173,11 @@ module "kubernetes-addons" {
   enable_agones = true
   # Optional  agones_helm_chart
   agones_helm_config = {
-    name               = "agones"
-    chart              = "agones"
-    repository         = "https://agones.dev/chart/stable"
-    version            = "1.15.0"
-    namespace          = "kube-system"
-    gameserver_minport = 7000 # required for sec group changes to worker nodes
-    gameserver_maxport = 8000 # required for sec group changes to worker nodes
+    name       = "agones"
+    chart      = "agones"
+    repository = "https://agones.dev/chart/stable"
+    version    = "1.21.0"
+    namespace  = "agones-system" # Agones recommends to install in it's own namespace such as `agones-system` as shown here. You can specify any namespace here other than `kube-system`
     values = [templatefile("${path.module}/helm_values/agones-values.yaml", {
       expose_udp            = true
       gameserver_namespaces = "{${join(",", ["default", "xbox-gameservers", "xbox-gameservers"])}}"


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Agones example update with correct namespace
- Docs update with latest info
- Agones helm chart version uplift
- Agones Add-on readme update

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
