### PR TITLE
update terraform-aws-module/eks to v18.17.0 to fix cloudwatch logs issue

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,0 +1,89 @@
+# Known Issues
+
+## Timeouts on destroy
+
+Customers who are deleting their environments using `terraform destroy` may see timeout errors when VPCs are being deleted. This is due to a known issue in the [vpc-cni](https://github.com/aws/amazon-vpc-cni-k8s/issues/1223#issue-704536542)
+
+Customers may face a situation where ENIs that were attached to EKS managed nodes (same may apply to self-managed nodes) are not being deleted by the VPC CNI as expected.
+
+This leads into situations where customers trying to cleanup their environment via IaC tools (CloudFormation/Terraform etc.) where the VPC components can’t be deleted - which leads to IaC tool failures. Reasons:
+
+* ENIs are left on subnets , while the IaC not managing those ENIs,  you are not allowed to delete subnets until the ENIs are properly cleaned, therefore the IaC cleanup will fail.
+* EKS managed security group which is attached to the ENI can’t be deleted by EKS (see arn):
+
+```json
+{
+    "eventVersion": "1.08",
+    "userIdentity": {
+        "type": "AssumedRole",
+        "principalId": "AROAXWEUFIYRVLF6F7CRF:AmazonEKS",
+        "arn": "arn:aws:sts::XXXXXXXXXX:assumed-role/AWSServiceRoleForAmazonEKS/AmazonEKS",
+        "accountId": "XXXXXXXX",
+        "sessionContext": {
+            "sessionIssuer": {
+                "type": "Role",
+                "principalId": "AROAXWEUFIYRVLF6F7CRF",
+                "arn": "arn:aws:iam::XXXXXXXXXX:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS",
+                "accountId": "XXXXXXXXX",
+                "userName": "AWSServiceRoleForAmazonEKS"
+            },
+            "webIdFederationData": {},
+            "attributes": {
+                "creationDate": "2022-03-29T16:28:44Z",
+                "mfaAuthenticated": "false"
+            }
+        },
+        "invokedBy": "eks.amazonaws.com"
+    },
+    "eventTime": "2022-03-29T16:28:48Z",
+    "eventSource": "ec2.amazonaws.com",
+    "eventName": "DeleteSecurityGroup",
+    "awsRegion": "us-west-2",
+    "sourceIPAddress": "eks.amazonaws.com",
+    "userAgent": "eks.amazonaws.com",
+    "errorCode": "Client.DependencyViolation",
+    "errorMessage": "resource sg-06efd8d3333bd0fa9 has a dependent object",
+    "requestParameters": {
+        "groupId": "sg-06efd8d3333bd0fa9"
+    },
+    "responseElements": null,
+    "requestID": "1592dc20-b3db-4447-8911-4572506107b0",
+    "eventID": "ac86cee0-80b7-4fe6-aab4-883d8443eb9e",
+    "readOnly": false,
+    "eventType": "AwsApiCall",
+    "managementEvent": true,
+    "recipientAccountId": "528591701539",
+    "eventCategory": "Management"
+}
+```
+
+(CloudTrail log example where EKS trying to delete the SG but can’t because it’s still used by the leaked ENI).
+
+After checking the CNI code and discussing the issue with EKS service team here’s what we understand:
+
+* The VPC CNI cleanup logic (at a very high level) is :
+  * Detach ENIs
+  * Delete ENIs
+
+Those are two different API operations, and post detaching ENI you may need for EC2 to properly detach the ENI which can take several seconds, the delete ENI does have a retry mechanism.
+
+If, during the time of delete calls, the nodes are also being terminated , we are in a state where the ENI are detached, but not deleted, therefore the term “Leak” used commonly.
+
+The current suggestion given by service team is to execute cleanup in the following order:
+
+1. delete all pods that have been created in the cluster.
+2. add delay/ wait
+3. delete VPC CNI
+4. delete nodes
+5. delete cluster
+
+The problem with this suggestion is the first point, IaC based solution (e.g. eksctl/EKS Blueprints etc.) not aware of all the pods existing in the cluster, as customer may deploy those pods outside of the used tool.
+
+## Leaked CloudWatch Logs Group
+
+Sometimes, customers may see the CloudWatch Log Group for EKS cluster being created is left behind after their blueprint has been destroyed using `terraform destroy`. This happens because even after terraform deletes the CW log group, there’s still logs being processed behind the scene by AWS EKS and service continues to write logs after recreating the log group using the EKS service IAM role which users don't have control over. This results in a terraform failure when the same blueprint is being recreated due to the existing log group left behind.
+
+There are two options here:
+
+1. During cluster creation set `var.create_cloudwatch_log_group` to `false` (default behavior). This will indicate to the upstream [terraform-aws-eks](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/6d7245621f97bb8e38642a9e40ddce3a32ff9efb/main.tf#L70) to not create the log group, but instead let the service create the log group. This means that upon cluster deletion the log group will be left behind but there will not be terraform failures if you re-create the same cluster as terraform does not manage the log group creation/deletion anymore.
+2. During cluster creation set `var.create_cloudwatch_log_group` to `true`. This will indicate to the upstream [terraform-aws-eks](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/6d7245621f97bb8e38642a9e40ddce3a32ff9efb/main.tf#L70) to create the log group via terraform. EKS service will detect the log group and will start forwarding the logs for the log types [enabled](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/6d7245621f97bb8e38642a9e40ddce3a32ff9efb/variables.tf#L35). Upon deletion terraform will delete the log group but depending upon any unforwarded logs, the EKS service may recreate log group using the service role. This will result in terraform errors if the same blueprint is recreated. To proceed, manually delete the log group using the console or cli rerun the `terraform apply`.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -4,80 +4,18 @@
 
 Customers who are deleting their environments using `terraform destroy` may see timeout errors when VPCs are being deleted. This is due to a known issue in the [vpc-cni](https://github.com/aws/amazon-vpc-cni-k8s/issues/1223#issue-704536542)
 
-Customers may face a situation where ENIs that were attached to EKS managed nodes (same may apply to self-managed nodes) are not being deleted by the VPC CNI as expected.
+Customers may face a situation where ENIs that were attached to EKS managed nodes (same may apply to self-managed nodes) are not being deleted by the VPC CNI as expected which leads to IaC tool failures, such as:
 
-This leads into situations where customers trying to cleanup their environment via IaC tools (CloudFormation/Terraform etc.) where the VPC components can’t be deleted - which leads to IaC tool failures. Reasons:
+* ENIs are left on subnets
+* EKS managed security group which is attached to the ENI can’t be deleted by EKS
 
-* ENIs are left on subnets , while the IaC not managing those ENIs,  you are not allowed to delete subnets until the ENIs are properly cleaned, therefore the IaC cleanup will fail.
-* EKS managed security group which is attached to the ENI can’t be deleted by EKS (see arn):
-
-```json
-{
-    "eventVersion": "1.08",
-    "userIdentity": {
-        "type": "AssumedRole",
-        "principalId": "AROAXWEUFIYRVLF6F7CRF:AmazonEKS",
-        "arn": "arn:aws:sts::XXXXXXXXXX:assumed-role/AWSServiceRoleForAmazonEKS/AmazonEKS",
-        "accountId": "XXXXXXXX",
-        "sessionContext": {
-            "sessionIssuer": {
-                "type": "Role",
-                "principalId": "AROAXWEUFIYRVLF6F7CRF",
-                "arn": "arn:aws:iam::XXXXXXXXXX:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS",
-                "accountId": "XXXXXXXXX",
-                "userName": "AWSServiceRoleForAmazonEKS"
-            },
-            "webIdFederationData": {},
-            "attributes": {
-                "creationDate": "2022-03-29T16:28:44Z",
-                "mfaAuthenticated": "false"
-            }
-        },
-        "invokedBy": "eks.amazonaws.com"
-    },
-    "eventTime": "2022-03-29T16:28:48Z",
-    "eventSource": "ec2.amazonaws.com",
-    "eventName": "DeleteSecurityGroup",
-    "awsRegion": "us-west-2",
-    "sourceIPAddress": "eks.amazonaws.com",
-    "userAgent": "eks.amazonaws.com",
-    "errorCode": "Client.DependencyViolation",
-    "errorMessage": "resource sg-06efd8d3333bd0fa9 has a dependent object",
-    "requestParameters": {
-        "groupId": "sg-06efd8d3333bd0fa9"
-    },
-    "responseElements": null,
-    "requestID": "1592dc20-b3db-4447-8911-4572506107b0",
-    "eventID": "ac86cee0-80b7-4fe6-aab4-883d8443eb9e",
-    "readOnly": false,
-    "eventType": "AwsApiCall",
-    "managementEvent": true,
-    "recipientAccountId": "528591701539",
-    "eventCategory": "Management"
-}
-```
-
-(CloudTrail log example where EKS trying to delete the SG but can’t because it’s still used by the leaked ENI).
-
-After checking the CNI code and discussing the issue with EKS service team here’s what we understand:
-
-* The VPC CNI cleanup logic (at a very high level) is :
-  * Detach ENIs
-  * Delete ENIs
-
-Those are two different API operations, and post detaching ENI you may need for EC2 to properly detach the ENI which can take several seconds, the delete ENI does have a retry mechanism.
-
-If, during the time of delete calls, the nodes are also being terminated , we are in a state where the ENI are detached, but not deleted, therefore the term “Leak” used commonly.
-
-The current suggestion given by service team is to execute cleanup in the following order:
+The current recommendation is to execute cleanup in the following order:
 
 1. delete all pods that have been created in the cluster.
 2. add delay/ wait
 3. delete VPC CNI
 4. delete nodes
 5. delete cluster
-
-The problem with this suggestion is the first point, IaC based solution (e.g. eksctl/EKS Blueprints etc.) not aware of all the pods existing in the cluster, as customer may deploy those pods outside of the used tool.
 
 ## Leaked CloudWatch Logs Group
 
@@ -86,4 +24,5 @@ Sometimes, customers may see the CloudWatch Log Group for EKS cluster being crea
 There are two options here:
 
 1. During cluster creation set `var.create_cloudwatch_log_group` to `false` (default behavior). This will indicate to the upstream [terraform-aws-eks](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/6d7245621f97bb8e38642a9e40ddce3a32ff9efb/main.tf#L70) to not create the log group, but instead let the service create the log group. This means that upon cluster deletion the log group will be left behind but there will not be terraform failures if you re-create the same cluster as terraform does not manage the log group creation/deletion anymore.
+
 2. During cluster creation set `var.create_cloudwatch_log_group` to `true`. This will indicate to the upstream [terraform-aws-eks](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/6d7245621f97bb8e38642a9e40ddce3a32ff9efb/main.tf#L70) to create the log group via terraform. EKS service will detect the log group and will start forwarding the logs for the log types [enabled](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/6d7245621f97bb8e38642a9e40ddce3a32ff9efb/variables.tf#L35). Upon deletion terraform will delete the log group but depending upon any unforwarded logs, the EKS service may recreate log group using the service role. This will result in terraform errors if the same blueprint is recreated. To proceed, manually delete the log group using the console or cli rerun the `terraform apply`.

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ To submit code for this Quick Start, see the AWS Quick Start [Contributor's guid
 | <a name="input_cluster_service_ipv4_cidr"></a> [cluster\_service\_ipv4\_cidr](#input\_cluster\_service\_ipv4\_cidr) | The CIDR block to assign Kubernetes service IP addresses from. If you don't specify a block, Kubernetes assigns addresses from either the 10.100.0.0/16 or 172.20.0.0/16 CIDR blocks | `string` | `null` | no |
 | <a name="input_cluster_timeouts"></a> [cluster\_timeouts](#input\_cluster\_timeouts) | Create, update, and delete timeout configurations for the cluster | `map(string)` | `{}` | no |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Kubernetes `<major>.<minor>` version to use for the EKS cluster (i.e.: `1.21`) | `string` | `"1.21"` | no |
+| <a name="input_create_cloudwatch_log_group"></a> [create\_cloudwatch\_log\_group](#input\_create\_cloudwatch\_log\_group) | Determines whether a log group is created by this module for the cluster logs. If not, AWS will automatically create one if logging is enabled | `bool` | `false` | no |
 | <a name="input_create_eks"></a> [create\_eks](#input\_create\_eks) | Create EKS cluster | `bool` | `true` | no |
 | <a name="input_custom_oidc_thumbprints"></a> [custom\_oidc\_thumbprints](#input\_custom\_oidc\_thumbprints) | Additional list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s) | `list(string)` | `[]` | no |
 | <a name="input_emr_on_eks_teams"></a> [emr\_on\_eks\_teams](#input\_emr\_on\_eks\_teams) | EMR on EKS Teams config | `any` | `{}` | no |
@@ -208,7 +209,7 @@ To submit code for this Quick Start, see the AWS Quick Start [Contributor's guid
 | <a name="input_public_subnet_ids"></a> [public\_subnet\_ids](#input\_public\_subnet\_ids) | List of public subnets Ids for the worker nodes | `list(string)` | `[]` | no |
 | <a name="input_self_managed_node_groups"></a> [self\_managed\_node\_groups](#input\_self\_managed\_node\_groups) | Self-managed node groups configuration | `any` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit`,`XYZ`) | `map(string)` | `{}` | no |
-| <a name="input_tenant"></a> [tenant](#input\_tenant) | Account Name or unique account unique id e.g., apps or management or aws007 | `string` | `"aws"` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | Account name or unique account id e.g., apps or management or aws007 | `string` | `"aws"` | no |
 | <a name="input_terraform_version"></a> [terraform\_version](#input\_terraform\_version) | Terraform version | `string` | `"Terraform"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC Id | `string` | n/a | yes |
 | <a name="input_worker_additional_security_group_ids"></a> [worker\_additional\_security\_group\_ids](#input\_worker\_additional\_security\_group\_ids) | A list of additional security group ids to attach to worker instances | `list(string)` | `[]` | no |
@@ -246,7 +247,6 @@ To submit code for this Quick Start, see the AWS Quick Start [Contributor's guid
 | <a name="output_windows_node_group_aws_auth_config_map"></a> [windows\_node\_group\_aws\_auth\_config\_map](#output\_windows\_node\_group\_aws\_auth\_config\_map) | Windows node groups AWS auth map |
 | <a name="output_worker_node_security_group_arn"></a> [worker\_node\_security\_group\_arn](#output\_worker\_node\_security\_group\_arn) | Amazon Resource Name (ARN) of the worker node shared security group |
 | <a name="output_worker_node_security_group_id"></a> [worker\_node\_security\_group\_id](#output\_worker\_node\_security\_group\_id) | ID of the worker node shared security group |
-
 <!--- END_TF_DOCS --->
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ To submit code for this Quick Start, see the AWS Quick Start [Contributor's guid
 | <a name="output_windows_node_group_aws_auth_config_map"></a> [windows\_node\_group\_aws\_auth\_config\_map](#output\_windows\_node\_group\_aws\_auth\_config\_map) | Windows node groups AWS auth map |
 | <a name="output_worker_node_security_group_arn"></a> [worker\_node\_security\_group\_arn](#output\_worker\_node\_security\_group\_arn) | Amazon Resource Name (ARN) of the worker node shared security group |
 | <a name="output_worker_node_security_group_id"></a> [worker\_node\_security\_group\_id](#output\_worker\_node\_security\_group\_id) | ID of the worker node shared security group |
+
 <!--- END_TF_DOCS --->
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ To submit code for this Quick Start, see the AWS Quick Start [Contributor's guid
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.73.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.66.0 |
 | <a name="provider_http"></a> [http](#provider\_http) | 2.4.1 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.7.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.7.1 |
 
 ## Modules
 
@@ -246,6 +246,7 @@ To submit code for this Quick Start, see the AWS Quick Start [Contributor's guid
 | <a name="output_windows_node_group_aws_auth_config_map"></a> [windows\_node\_group\_aws\_auth\_config\_map](#output\_windows\_node\_group\_aws\_auth\_config\_map) | Windows node groups AWS auth map |
 | <a name="output_worker_node_security_group_arn"></a> [worker\_node\_security\_group\_arn](#output\_worker\_node\_security\_group\_arn) | Amazon Resource Name (ARN) of the worker node shared security group |
 | <a name="output_worker_node_security_group_id"></a> [worker\_node\_security\_group\_id](#output\_worker\_node\_security\_group\_id) | ID of the worker node shared security group |
+
 <!--- END_TF_DOCS --->
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -127,15 +127,15 @@ To submit code for this Quick Start, see the AWS Quick Start [Contributor's guid
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.66.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.73.0 |
 | <a name="provider_http"></a> [http](#provider\_http) | 2.4.1 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.7.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.7.1 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_eks"></a> [aws\_eks](#module\_aws\_eks) | terraform-aws-modules/eks/aws | v18.10.0 |
+| <a name="module_aws_eks"></a> [aws\_eks](#module\_aws\_eks) | terraform-aws-modules/eks/aws | v18.17.0 |
 | <a name="module_aws_eks_fargate_profiles"></a> [aws\_eks\_fargate\_profiles](#module\_aws\_eks\_fargate\_profiles) | ./modules/aws-eks-fargate-profiles | n/a |
 | <a name="module_aws_eks_managed_node_groups"></a> [aws\_eks\_managed\_node\_groups](#module\_aws\_eks\_managed\_node\_groups) | ./modules/aws-eks-managed-node-groups | n/a |
 | <a name="module_aws_eks_self_managed_node_groups"></a> [aws\_eks\_self\_managed\_node\_groups](#module\_aws\_eks\_self\_managed\_node\_groups) | ./modules/aws-eks-self-managed-node-groups | n/a |
@@ -246,7 +246,6 @@ To submit code for this Quick Start, see the AWS Quick Start [Contributor's guid
 | <a name="output_windows_node_group_aws_auth_config_map"></a> [windows\_node\_group\_aws\_auth\_config\_map](#output\_windows\_node\_group\_aws\_auth\_config\_map) | Windows node groups AWS auth map |
 | <a name="output_worker_node_security_group_arn"></a> [worker\_node\_security\_group\_arn](#output\_worker\_node\_security\_group\_arn) | Amazon Resource Name (ARN) of the worker node shared security group |
 | <a name="output_worker_node_security_group_id"></a> [worker\_node\_security\_group\_id](#output\_worker\_node\_security\_group\_id) | ID of the worker node shared security group |
-
 <!--- END_TF_DOCS --->
 
 ## Security

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ module "kms" {
 # ---------------------------------------------------------------------------------------------------------------------
 module "aws_eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "v18.10.0"
+  version = "v18.17.0"
   create  = var.create_eks
 
   cluster_name     = var.cluster_name == "" ? module.eks_tags.id : var.cluster_name

--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,7 @@ module "aws_eks" {
   tags = module.eks_tags.tags
 
   # CLUSTER LOGGING
+  create_cloudwatch_log_group            = var.create_cloudwatch_log_group
   cluster_enabled_log_types              = var.cluster_enabled_log_types # no change
   cloudwatch_log_group_retention_in_days = var.cloudwatch_log_group_retention_in_days
   cloudwatch_log_group_kms_key_id        = var.cloudwatch_log_group_kms_key_id

--- a/variables.tf
+++ b/variables.tf
@@ -165,6 +165,12 @@ variable "cluster_service_ipv4_cidr" {
 #-------------------------------
 # EKS Cluster CloudWatch Logging
 #-------------------------------
+variable "create_cloudwatch_log_group" {
+  description = "Determines whether a log group is created by this module for the cluster logs. If not, AWS will automatically create one if logging is enabled"
+  type        = bool
+  default     = false
+}
+
 variable "cluster_enabled_log_types" {
   type        = list(string)
   default     = ["api", "audit", "authenticator", "controllerManager", "scheduler"]


### PR DESCRIPTION
### What does this PR do?

Fixes orphaned cloudwatch logs group that's sometimes left over after destroy.

### Motivation

https://github.com/aws-ia/terraform-ssp-amazon-eks/issues/203

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [x] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
