### PR TITLE
ci: Update `pre-commit` workflow to use latest upstream changes

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,97 +1,77 @@
 name: pre-commit
 
 on:
-  push:
+  pull_request:
     branches:
       - main
 
+env:
+  TERRAFORM_DOCS_VERSION: v0.16.0
+
 jobs:
-  # Min Terraform version(s)
-  getDirectories:
-    name: Get root directories
+  collectInputs:
+    name: Collect workflow inputs
     runs-on: ubuntu-latest
+    outputs:
+      directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install Python
-        uses: actions/setup-python@v2
-      - name: Build matrix
-        id: matrix
-        run: |
-          DIRS=$(python -c "import json; import glob; print(json.dumps([x.replace('/versions.tf', '') for x in glob.glob('./**/versions.tf', recursive=True)]))")
-          echo "::set-output name=directories::$DIRS"
-    outputs:
-      directories: ${{ steps.matrix.outputs.directories }}
+
+      - name: Get root directories
+        id: dirs
+        uses: clowdhaus/terraform-composite-actions/directories@v1.4.1
 
   preCommitMinVersions:
-    name: Min TF validate
-    needs: getDirectories
+    name: Min TF pre-commit
+    needs: collectInputs
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        directory: ${{ fromJson(needs.getDirectories.outputs.directories) }}
+        directory: ${{ fromJson(needs.collectInputs.outputs.directories) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install Python
-        uses: actions/setup-python@v2
+
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.0.2
+        uses: clowdhaus/terraform-min-max@v1.0.7
         with:
           directory: ${{ matrix.directory }}
-      - name: Install Terraform v${{ steps.minMax.outputs.minVersion }}
-        uses: hashicorp/setup-terraform@v1
-        with:
-          terraform_version: ${{ steps.minMax.outputs.minVersion }}
-      - name: Install pre-commit dependencies
-        run: pip install pre-commit
-      - name: Execute pre-commit
+
+      - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory !=  '.' }}
-        run: pre-commit run terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*
-      - name: Execute pre-commit
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.4.1
+        with:
+          terraform-version: ${{ steps.minMax.outputs.minVersion }}
+          args: 'terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*'
+
+      - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory ==  '.' }}
-        run: pre-commit run terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)
-
-  # Max Terraform version
-  getBaseVersion:
-    name: Module max TF version
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Terraform min/max versions
-        id: minMax
-        uses: clowdhaus/terraform-min-max@v1.0.2
-    outputs:
-      minVersion: ${{ steps.minMax.outputs.minVersion }}
-      maxVersion: ${{ steps.minMax.outputs.maxVersion }}
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.4.1
+        with:
+          terraform-version: ${{ steps.minMax.outputs.minVersion }}
+          args: 'terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)'
 
   preCommitMaxVersion:
     name: Max TF pre-commit
     runs-on: ubuntu-latest
-    needs: getBaseVersion
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - ${{ needs.getBaseVersion.outputs.maxVersion }}
+    needs: collectInputs
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install Python
-        uses: actions/setup-python@v2
-      - name: Install Terraform v${{ matrix.version }}
-        uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: ${{ matrix.version }}
-      - name: Install pre-commit dependencies
-        run: |
-          pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
-      - name: Execute pre-commit
-        # Run all pre-commit checks on max version supported
-        if: ${{ matrix.version ==  needs.getBaseVersion.outputs.maxVersion }}
-        run: pre-commit run --color=always --show-diff-on-failure --all-files
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Terraform min/max versions
+        id: minMax
+        uses: clowdhaus/terraform-min-max@v1.0.7
+
+      - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.4.1
+        with:
+          terraform-version: ${{ steps.minMax.outputs.maxVersion }}
+          terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}


### PR DESCRIPTION
### What does this PR do?
- Update `pre-commit` workflow to use latest upstream changes
	- Actions used are updated to latest to patch any reported vulnerabilities in the underlying action source code
	- Workflow utilizes composite actions which provides the same functionality here but in simplified steps
- Convert workflow to run on pull requests - see more details on https://github.com/aws-samples/aws-eks-accelerator-for-terraform/pull/377 related to `pr-test.yml` and `pre-commit.yaml`

### Motivation
- I believe we want this workflow to run on pull requests so that users can receive this feedback on their PRs. Currently it runs after pushed to `main` (merge or direct commit) which is too late to tell users if they need to make any changes to pass the static checks. I started to add this in https://github.com/aws-samples/aws-eks-accelerator-for-terraform/pull/377 but I can't change it and get it to run in the same PR as an outside contributor so splitting out to a separate PR

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes
