### PR TITLE
Fix/restrict worker node instance profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ To submit code for this Quick Start, see the AWS Quick Start [Contributor's guid
 | <a name="input_public_subnet_ids"></a> [public\_subnet\_ids](#input\_public\_subnet\_ids) | List of public subnets Ids for the worker nodes | `list(string)` | `[]` | no |
 | <a name="input_self_managed_node_groups"></a> [self\_managed\_node\_groups](#input\_self\_managed\_node\_groups) | Self-managed node groups configuration | `any` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit`,`XYZ`) | `map(string)` | `{}` | no |
-| <a name="input_tenant"></a> [tenant](#input\_tenant) | Account Name or unique account unique id e.g., apps or management or aws007 | `string` | `"aws"` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | Account name or unique account id e.g., apps or management or aws007 | `string` | `"aws"` | no |
 | <a name="input_terraform_version"></a> [terraform\_version](#input\_terraform\_version) | Terraform version | `string` | `"Terraform"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC Id | `string` | n/a | yes |
 | <a name="input_worker_additional_security_group_ids"></a> [worker\_additional\_security\_group\_ids](#input\_worker\_additional\_security\_group\_ids) | A list of additional security group ids to attach to worker instances | `list(string)` | `[]` | no |

--- a/examples/node-groups/managed-node-groups/main.tf
+++ b/examples/node-groups/managed-node-groups/main.tf
@@ -398,7 +398,7 @@ module "aws-eks-accelerator-for-terraform" {
       disk_size      = 50
 
       # 4> Node Group network configuration
-      subnet_ids = [] # Defaults to private subnet-ids used by EKS Controle plane. Define your private/public subnets list with comma separated subnet_ids  = ['subnet1','subnet2','subnet3']
+      subnet_ids = [] # Defaults to private subnet-ids used by EKS Control plane. Define your private/public subnets list with comma separated subnet_ids  = ['subnet1','subnet2','subnet3']
 
       k8s_taints = []
 

--- a/examples/node-groups/managed-node-groups/main.tf
+++ b/examples/node-groups/managed-node-groups/main.tf
@@ -375,7 +375,7 @@ module "aws-eks-accelerator-for-terraform" {
     #---------------------------------------------------------#
     # Bottlerocket instance type Worker Group
     #---------------------------------------------------------#
-    bottlerocket_arm = {
+    bottlerocket_x86 = {
       # 1> Node Group configuration - Part1
       node_group_name        = "btl-x86"      # Max 40 characters for node group name
       create_launch_template = true           # false will use the default launch template

--- a/locals.tf
+++ b/locals.tf
@@ -12,7 +12,7 @@ locals {
     # http details
     http_endpoint               = "enabled"
     http_tokens                 = "required"
-    http_put_response_hop_limit = 2 # Hop limit should be between 2 and 64 for IMDSv2 instance metadata services
+    http_put_response_hop_limit = 1
   }
 
   eks_cluster_id     = module.aws_eks.cluster_id

--- a/modules/launch-templates/locals.tf
+++ b/modules/launch-templates/locals.tf
@@ -37,7 +37,7 @@ locals {
 
     http_endpoint               = "enabled"
     http_tokens                 = "required"
-    http_put_response_hop_limit = 2
+    http_put_response_hop_limit = 1
 
     monitoring = true
   })


### PR DESCRIPTION
### What does this PR do?

Restricts access to instance profiles in worker node groups by:
 - disabling imds access for self-managed node groups by updating the default metadata_options in the launch-templates module:
 ```
    http_endpoint               = "enabled"
    http_tokens                 = "required"
    http_put_response_hop_limit = 1
```
 - disabling imds access for managed node groups by updating the default context in the root module:
```
    http_endpoint               = "enabled"
    http_tokens                 = "required"
    http_put_response_hop_limit = 1
```

Previously there was a comment in the code saying "Hop limit should be between 2 and 64 for IMDSv2 instance metadata services", but that is likely outdated as the [guidance here](https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node) recommends setting the hop limit to 1.

This PR also fixes a typo in the managed node group example. The x86 bottlerocket managed node group entry was named "bottlerocket_arm". I renamed this to "bottlerocket_x86".

### Motivation

Restricting access to the instance profiles in worker node groups minimizes the blast radius of a breach as described in the best practices guide above.

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

Testing notes:
   - Deployed a managed node group and a self-managed node group, accessed their respective EC2 instances and tried a request to IMDSv1 using `curl -v http://169.254.169.254/latest/meta-data/` and confirmed I received an "Unauthorized" response.

