### PR TITLE
fix: correct agones SA values

### DIFF
--- a/examples/game-tech/agones-game-controller/helm_values/agones-values.yaml
+++ b/examples/game-tech/agones-game-controller/helm_values/agones-values.yaml
@@ -14,9 +14,12 @@ agones:
     install: true
     cleanupOnDelete: true
   serviceaccount:
-    controller: agones-controller
-    sdk: agones-sdk
-    allocator: agones-allocator
+    controller::
+      name: agones-controller
+    sdk:
+      name: agones-sdk
+    allocator:
+      name: agones-allocator
   createPriorityClass: true
   priorityClassName: agones-system
   controller:


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Fixing helm values for agones example, correct service account names

### Motivation

<!-- What inspired you to submit this pull request? -->
- Currently agones example failing due to wrong helm values setup, SA names should be under `name:` key.

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
