### PR TITLE
fix: re-add sleep to crossplane aws provider

### DIFF
--- a/modules/kubernetes-addons/crossplane/README.md
+++ b/modules/kubernetes-addons/crossplane/README.md
@@ -38,6 +38,7 @@ ___
 | <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 | <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 1.13.1 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | n/a |
+| <a name="provider_time"></a> [time](#provider\_time) | n/a |
 
 ## Modules
 
@@ -60,6 +61,7 @@ ___
 | [kubectl_manifest.jet_aws_provider](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.jet_aws_provider_config](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubernetes_namespace_v1.crossplane](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
+| [time_sleep.wait_30_seconds](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_iam_policy_document.s3_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs

--- a/modules/kubernetes-addons/crossplane/main.tf
+++ b/modules/kubernetes-addons/crossplane/main.tf
@@ -39,6 +39,13 @@ resource "kubectl_manifest" "aws_provider" {
   depends_on = [kubectl_manifest.aws_controller_config]
 }
 
+# Wait for the AWS Provider CRDs to be fully created before initiating aws_provider_config deployment
+resource "time_sleep" "wait_30_seconds" {
+  depends_on = [kubectl_manifest.aws_provider]
+
+  create_duration = "30s"
+}
+
 module "aws_provider_irsa" {
   count                             = var.aws_provider.enable == true ? 1 : 0
   source                            = "../../../modules/irsa"
@@ -64,7 +71,7 @@ resource "kubectl_manifest" "aws_provider_config" {
   count     = var.aws_provider.enable == true ? 1 : 0
   yaml_body = templatefile("${path.module}/aws-provider/aws-provider-config.yaml", {})
 
-  depends_on = [kubectl_manifest.aws_provider]
+  depends_on = [kubectl_manifest.aws_provider, time_sleep.wait_30_seconds]
 }
 
 #--------------------------------------


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- add hard coded 30 sec sleep between crossplane aws provider manifest and aws provider config manifest

### Motivation

<!-- What inspired you to submit this pull request? -->
- We've seen failures deploying crossplane example due to crossplane provider CRDs not deployed yet while custom APIs manifests trying to be deployed, leading to errors such as:
```
Error: aws-provider-config failed to create kubernetes rest client for update of resource: resource [aws.crossplane.io/v1beta1/ProviderConfig] isn't valid for cluster, check the APIVersion and Kind fields are valid[2350](https://github.com/Zvikan/aws-eks-accelerator-for-terraform/runs/5740005740?check_suite_focus=true#step:10:2350)[2351](https://github.com/Zvikan/aws-eks-accelerator-for-terraform/runs/5740005740?check_suite_focus=true#step:10:2351)  with module.e2e-test.module.kubernetes-addons.module.crossplane[0].kubectl_manifest.aws_provider_config[0],[2352](https://github.com/Zvikan/aws-eks-accelerator-for-terraform/runs/5740005740?check_suite_focus=true#step:10:2352)  on ../../../modules/kubernetes-addons/crossplane/main.tf line 63, in resource "kubectl_manifest" "aws_provider_config":[2353](https://github.com/Zvikan/aws-eks-accelerator-for-terraform/runs/5740005740?check_suite_focus=true#step:10:2353)  63: resource "kubectl_manifest" "aws_provider_config" {
```
Since the CRDs are not deployed via the helm chart but through the provider, there's no known way to create an explicit wait until CRDs are properly deployed before continuing, and because of that, the hard coded sleep between the two resources helps for smoother deployment experience. 

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
