### PR TITLE
Karpenter fix for AMI and sec group rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ To submit code for this Quick Start, see the AWS Quick Start [Contributor's guid
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Kubernetes `<major>.<minor>` version to use for the EKS cluster (i.e.: `1.21`) | `string` | `"1.21"` | no |
 | <a name="input_create_cloudwatch_log_group"></a> [create\_cloudwatch\_log\_group](#input\_create\_cloudwatch\_log\_group) | Determines whether a log group is created by this module for the cluster logs. If not, AWS will automatically create one if logging is enabled | `bool` | `false` | no |
 | <a name="input_create_eks"></a> [create\_eks](#input\_create\_eks) | Create EKS cluster | `bool` | `true` | no |
+| <a name="input_create_node_security_group"></a> [create\_node\_security\_group](#input\_create\_node\_security\_group) | Determines whether to create a security group for the node groups or use the existing `node_security_group_id` | `bool` | `true` | no |
 | <a name="input_custom_oidc_thumbprints"></a> [custom\_oidc\_thumbprints](#input\_custom\_oidc\_thumbprints) | Additional list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s) | `list(string)` | `[]` | no |
 | <a name="input_emr_on_eks_teams"></a> [emr\_on\_eks\_teams](#input\_emr\_on\_eks\_teams) | EMR on EKS Teams config | `any` | `{}` | no |
 | <a name="input_enable_amazon_prometheus"></a> [enable\_amazon\_prometheus](#input\_enable\_amazon\_prometheus) | Enable AWS Managed Prometheus service | `bool` | `false` | no |
@@ -202,6 +203,7 @@ To submit code for this Quick Start, see the AWS Quick Start [Contributor's guid
 | <a name="input_map_accounts"></a> [map\_accounts](#input\_map\_accounts) | Additional AWS account numbers to add to the aws-auth ConfigMap | `list(string)` | `[]` | no |
 | <a name="input_map_roles"></a> [map\_roles](#input\_map\_roles) | Additional IAM roles to add to the aws-auth ConfigMap | <pre>list(object({<br>    rolearn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_map_users"></a> [map\_users](#input\_map\_users) | Additional IAM users to add to the aws-auth ConfigMap | <pre>list(object({<br>    userarn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_node_security_group_additional_rules"></a> [node\_security\_group\_additional\_rules](#input\_node\_security\_group\_additional\_rules) | List of additional security group rules to add to the node security group created. Set `source_cluster_security_group = true` inside rules to set the `cluster_security_group` as source | `any` | `{}` | no |
 | <a name="input_openid_connect_audiences"></a> [openid\_connect\_audiences](#input\_openid\_connect\_audiences) | List of OpenID Connect audience client IDs to add to the IRSA provider | `list(string)` | `[]` | no |
 | <a name="input_org"></a> [org](#input\_org) | tenant, which could be your organization name, e.g. aws' | `string` | `""` | no |
 | <a name="input_platform_teams"></a> [platform\_teams](#input\_platform\_teams) | Map of maps of platform teams to create | `any` | `{}` | no |

--- a/examples/crossplane/main.tf
+++ b/examples/crossplane/main.tf
@@ -64,7 +64,7 @@ provider "kubectl" {
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
   load_config_file       = false
-  apply_retry_count      = 5
+  apply_retry_count      = 30
 }
 
 locals {

--- a/examples/karpenter/README.md
+++ b/examples/karpenter/README.md
@@ -115,6 +115,8 @@ terraform destroy
 | Name | Type |
 |------|------|
 | [kubectl_manifest.karpenter_provisioner](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [aws_ami.amazonlinux2eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_ami.bottlerocket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_eks_cluster_auth.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -147,18 +147,6 @@ module "aws-eks-accelerator-for-terraform" {
   # EKS CONTROL PLANE VARIABLES
   cluster_version = local.cluster_version
 
-  # Extend cluster security group rule to allow Karpenter service to communicate with Cluster API
-  cluster_security_group_additional_rules = {
-    ingress_nodes_karpenter_port = {
-      description                = "From node 8443 for Karpenter"
-      protocol                   = "tcp"
-      from_port                  = 8443
-      to_port                    = 8443
-      type                       = "ingress"
-      source_node_security_group = true
-    }
-  }
-
   # Allow Worker nodes egress to talk to Cluster API for Karpenter service
   node_security_group_additional_rules = {
     egress_nodes_karpenter_port = {

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -162,11 +162,19 @@ module "aws-eks-accelerator-for-terraform" {
   # Allow Worker nodes egress to talk to Cluster API for Karpenter service
   node_security_group_additional_rules = {
     egress_nodes_karpenter_port = {
-      description                   = "Node groups to cluster API"
+      description                   = "Node groups to cluster API for Karpenter"
       protocol                      = "tcp"
       from_port                     = 8443
       to_port                       = 8443
       type                          = "egress"
+      source_cluster_security_group = true
+    }
+    ingress_nodes_karpenter_port = {
+      description                   = "Cluster API to Nodegroup for Karpenter"
+      protocol                      = "tcp"
+      from_port                     = 8443
+      to_port                       = 8443
+      type                          = "ingress"
       source_cluster_security_group = true
     }
   }

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -147,7 +147,7 @@ module "aws-eks-accelerator-for-terraform" {
   # EKS CONTROL PLANE VARIABLES
   cluster_version = local.cluster_version
 
-  # Allow Worker nodes egress to talk to Cluster API for Karpenter service
+  # Allow Ingress rule for Worker node groups from Cluster Sec group for Karpenter
   node_security_group_additional_rules = {
     ingress_nodes_karpenter_port = {
       description                   = "Cluster API to Nodegroup for Karpenter"

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -149,14 +149,6 @@ module "aws-eks-accelerator-for-terraform" {
 
   # Allow Worker nodes egress to talk to Cluster API for Karpenter service
   node_security_group_additional_rules = {
-    egress_nodes_karpenter_port = {
-      description                   = "Node groups to cluster API for Karpenter"
-      protocol                      = "tcp"
-      from_port                     = 8443
-      to_port                       = 8443
-      type                          = "egress"
-      source_cluster_security_group = true
-    }
     ingress_nodes_karpenter_port = {
       description                   = "Cluster API to Nodegroup for Karpenter"
       protocol                      = "tcp"

--- a/main.tf
+++ b/main.tf
@@ -56,10 +56,13 @@ module "aws_eks" {
 
   # Cluster Security Group
   create_cluster_security_group           = true
-  create_node_security_group              = true
   vpc_id                                  = var.vpc_id
   cluster_additional_security_group_ids   = var.cluster_additional_security_group_ids
   cluster_security_group_additional_rules = var.cluster_security_group_additional_rules
+
+  # Worker Node Security Group
+  create_node_security_group           = true
+  node_security_group_additional_rules = var.node_security_group_additional_rules
 
   # IRSA
   enable_irsa              = var.enable_irsa # no change

--- a/modules/aws-eks-self-managed-node-groups/locals.tf
+++ b/modules/aws-eks-self-managed-node-groups/locals.tf
@@ -45,6 +45,7 @@ locals {
     bottlerocket    = "bottlerocket-aws-k8s-${var.context.cluster_version}-x86_64-*"
     windows         = "Windows_Server-2019-English-Core-EKS_Optimized-${var.context.cluster_version}-*"
   }
+
   predefined_ami_types  = keys(local.predefined_ami_names)
   default_custom_ami_id = contains(local.predefined_ami_types, local.self_managed_node_group["launch_template_os"]) ? data.aws_ami.predefined[local.self_managed_node_group["launch_template_os"]].id : ""
   custom_ami_id         = local.self_managed_node_group["custom_ami_id"] == "" ? local.default_custom_ami_id : local.self_managed_node_group["custom_ami_id"]

--- a/variables.tf
+++ b/variables.tf
@@ -260,6 +260,19 @@ variable "enable_windows_support" {
 #-------------------------------
 # Worker Additional Variables
 #-------------------------------
+
+variable "create_node_security_group" {
+  description = "Determines whether to create a security group for the node groups or use the existing `node_security_group_id`"
+  type        = bool
+  default     = true
+}
+#rules added by
+variable "node_security_group_additional_rules" {
+  description = "List of additional security group rules to add to the node security group created. Set `source_cluster_security_group = true` inside rules to set the `cluster_security_group` as source"
+  type        = any
+  default     = {}
+}
+
 variable "worker_additional_security_group_ids" {
   description = "A list of additional security group ids to attach to worker instances"
   type        = list(string)


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

- Adds additional sec group rules to nodes and cluster sec groups as per Karpenter 
- Handling AMI as per the  current region

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [x] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
