### PR TITLE
fix: update mismatching configuration between gitops and helm provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ To submit code for this Quick Start, see the AWS Quick Start [Contributor's guid
 | <a name="input_public_subnet_ids"></a> [public\_subnet\_ids](#input\_public\_subnet\_ids) | List of public subnets Ids for the worker nodes | `list(string)` | `[]` | no |
 | <a name="input_self_managed_node_groups"></a> [self\_managed\_node\_groups](#input\_self\_managed\_node\_groups) | Self-managed node groups configuration | `any` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit`,`XYZ`) | `map(string)` | `{}` | no |
-| <a name="input_tenant"></a> [tenant](#input\_tenant) | Account Name or unique account unique id e.g., apps or management or aws007 | `string` | `"aws"` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | Account name or unique account id e.g., apps or management or aws007 | `string` | `"aws"` | no |
 | <a name="input_terraform_version"></a> [terraform\_version](#input\_terraform\_version) | Terraform version | `string` | `"Terraform"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC Id | `string` | n/a | yes |
 | <a name="input_worker_additional_security_group_ids"></a> [worker\_additional\_security\_group\_ids](#input\_worker\_additional\_security\_group\_ids) | A list of additional security group ids to attach to worker instances | `list(string)` | `[]` | no |

--- a/modules/kubernetes-addons/argo-rollouts/values.yaml
+++ b/modules/kubernetes-addons/argo-rollouts/values.yaml
@@ -1,3 +1,0 @@
-serviceAccount:
-  create: false
-  name: ${sa-name}

--- a/modules/kubernetes-addons/aws-for-fluentbit/locals.tf
+++ b/modules/kubernetes-addons/aws-for-fluentbit/locals.tf
@@ -19,7 +19,7 @@ locals {
     chart       = local.name
     repository  = "https://aws.github.io/eks-charts"
     version     = "0.1.11"
-    namespace   = "logging"
+    namespace   = local.name
     values      = local.default_helm_values
     description = "aws-for-fluentbit Helm Chart deployment configuration"
   }

--- a/modules/kubernetes-addons/aws-for-fluentbit/values.yaml
+++ b/modules/kubernetes-addons/aws-for-fluentbit/values.yaml
@@ -9,9 +9,12 @@ cloudWatch:
 
 firehose:
   enabled: false
+  region: ${aws_region}
 
 kinesis:
   enabled: false
+  region: ${aws_region}
 
 elasticsearch:
   enabled: false
+  region: ${aws_region}

--- a/modules/kubernetes-addons/aws-load-balancer-controller/locals.tf
+++ b/modules/kubernetes-addons/aws-load-balancer-controller/locals.tf
@@ -6,7 +6,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://aws.github.io/eks-charts"
-    version     = "1.3.1"
+    version     = "1.3.2"
     namespace   = "kube-system"
     timeout     = "1200"
     values      = local.default_helm_values
@@ -19,9 +19,8 @@ locals {
   )
 
   default_helm_values = [templatefile("${path.module}/values.yaml", {
-    aws_region           = var.addon_context.aws_region_name,
-    eks_cluster_id       = var.addon_context.eks_cluster_id,
-    service_account_name = local.service_account_name
+    aws_region     = var.addon_context.aws_region_name,
+    eks_cluster_id = var.addon_context.eks_cluster_id,
   })]
 
   set_values = [

--- a/modules/kubernetes-addons/aws-load-balancer-controller/values.yaml
+++ b/modules/kubernetes-addons/aws-load-balancer-controller/values.yaml
@@ -1,5 +1,2 @@
 clusterName: ${eks_cluster_id}
 region: ${aws_region}
-serviceAccount:
-  create: false
-  name: ${service_account_name}

--- a/modules/kubernetes-addons/aws-node-termination-handler/locals.tf
+++ b/modules/kubernetes-addons/aws-node-termination-handler/locals.tf
@@ -20,9 +20,7 @@ locals {
     var.helm_config
   )
 
-  default_helm_values = [templatefile("${path.module}/values.yaml", {
-    nth-sa-name = local.service_account_name
-  })]
+  default_helm_values = [templatefile("${path.module}/values.yaml", {})]
 
   set_values = [
     {

--- a/modules/kubernetes-addons/aws-node-termination-handler/values.yaml
+++ b/modules/kubernetes-addons/aws-node-termination-handler/values.yaml
@@ -1,8 +1,2 @@
----
-serviceAccount:
-  name: ${nth-sa-name}
-  create: false
-
 enableSqsTerminationDraining: true
-
 enablePrometheusServer: true

--- a/modules/kubernetes-addons/cert-manager/locals.tf
+++ b/modules/kubernetes-addons/cert-manager/locals.tf
@@ -8,12 +8,12 @@ locals {
     repository  = "https://charts.jetstack.io"
     version     = "v1.7.1"
     namespace   = local.name
-    description = "Argo Rollouts AddOn Helm Chart"
+    description = "Cert Manager AddOn Helm Chart"
     values      = local.default_helm_values
     timeout     = "600"
   }
 
-  default_helm_values = [templatefile("${path.module}/values.yaml", {})]
+  default_helm_values = []
 
   helm_config = merge(
     local.default_helm_config,

--- a/modules/kubernetes-addons/cluster-autoscaler/locals.tf
+++ b/modules/kubernetes-addons/cluster-autoscaler/locals.tf
@@ -14,9 +14,8 @@ locals {
   }
 
   default_helm_values = [templatefile("${path.module}/values.yaml", {
-    aws_region           = var.addon_context.aws_region_name,
-    eks_cluster_id       = var.addon_context.eks_cluster_id
-    service_account_name = local.service_account_name
+    aws_region     = var.addon_context.aws_region_name,
+    eks_cluster_id = var.addon_context.eks_cluster_id
   })]
 
   helm_config = merge(

--- a/modules/kubernetes-addons/cluster-autoscaler/values.yaml
+++ b/modules/kubernetes-addons/cluster-autoscaler/values.yaml
@@ -5,11 +5,6 @@ autoDiscovery:
 extraArgs:
   aws-use-static-instance-list: true
 
-rbac:
-  serviceAccount:
-    create: false
-    name: ${service_account_name}
-
 resources:
   limits:
     cpu: 200m

--- a/modules/kubernetes-addons/crossplane/README.md
+++ b/modules/kubernetes-addons/crossplane/README.md
@@ -75,8 +75,6 @@ ___
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_argocd_gitops_config"></a> [argocd\_gitops\_config](#output\_argocd\_gitops\_config) | Configuration used for managing the add-on with ArgoCD |
+No outputs.
 
 <!--- END_TF_DOCS --->

--- a/modules/kubernetes-addons/crossplane/README.md
+++ b/modules/kubernetes-addons/crossplane/README.md
@@ -72,7 +72,6 @@ ___
 | <a name="input_aws_provider"></a> [aws\_provider](#input\_aws\_provider) | AWS Provider config for Crossplane | <pre>object({<br>    enable                   = bool<br>    provider_aws_version     = string<br>    additional_irsa_policies = list(string)<br>  })</pre> | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for the Argo Rollouts | `any` | `{}` | no |
 | <a name="input_jet_aws_provider"></a> [jet\_aws\_provider](#input\_jet\_aws\_provider) | AWS Provider Jet AWS config for Crossplane | <pre>object({<br>    enable                   = bool<br>    provider_aws_version     = string<br>    additional_irsa_policies = list(string)<br>  })</pre> | n/a | yes |
-| <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/crossplane/locals.tf
+++ b/modules/kubernetes-addons/crossplane/locals.tf
@@ -24,8 +24,4 @@ locals {
   jet_aws_provider_sa    = "jet-aws-provider"
   aws_current_account_id = var.account_id
   aws_current_partition  = var.aws_partition
-
-  argocd_gitops_config = {
-    enable = true
-  }
 }

--- a/modules/kubernetes-addons/crossplane/main.tf
+++ b/modules/kubernetes-addons/crossplane/main.tf
@@ -9,11 +9,10 @@ resource "kubernetes_namespace_v1" "crossplane" {
 }
 
 module "helm_addon" {
-  source            = "../helm-addon"
-  manage_via_gitops = var.manage_via_gitops
-  helm_config       = local.helm_config
-  irsa_config       = null
-  addon_context     = var.addon_context
+  source        = "../helm-addon"
+  helm_config   = local.helm_config
+  irsa_config   = null
+  addon_context = var.addon_context
 
   depends_on = [kubernetes_namespace_v1.crossplane]
 }

--- a/modules/kubernetes-addons/crossplane/outputs.tf
+++ b/modules/kubernetes-addons/crossplane/outputs.tf
@@ -1,4 +1,0 @@
-output "argocd_gitops_config" {
-  description = "Configuration used for managing the add-on with ArgoCD"
-  value       = var.manage_via_gitops ? local.argocd_gitops_config : null
-}

--- a/modules/kubernetes-addons/crossplane/variables.tf
+++ b/modules/kubernetes-addons/crossplane/variables.tf
@@ -4,12 +4,6 @@ variable "helm_config" {
   default     = {}
 }
 
-variable "manage_via_gitops" {
-  type        = bool
-  default     = false
-  description = "Determines if the add-on should be managed via GitOps."
-}
-
 variable "aws_provider" {
   description = "AWS Provider config for Crossplane"
   type = object({

--- a/modules/kubernetes-addons/external-dns/locals.tf
+++ b/modules/kubernetes-addons/external-dns/locals.tf
@@ -14,8 +14,8 @@ locals {
   }
 
   default_helm_values = [templatefile("${path.module}/values.yaml", {
-    aws_region           = var.addon_context.aws_region_name
-    zone_filter_ids      = local.zone_filter_ids
+    aws_region      = var.addon_context.aws_region_name
+    zone_filter_ids = local.zone_filter_ids
   })]
 
   helm_config = merge(

--- a/modules/kubernetes-addons/external-dns/locals.tf
+++ b/modules/kubernetes-addons/external-dns/locals.tf
@@ -15,7 +15,6 @@ locals {
 
   default_helm_values = [templatefile("${path.module}/values.yaml", {
     aws_region           = var.addon_context.aws_region_name
-    service_account_name = local.service_account_name
     zone_filter_ids      = local.zone_filter_ids
   })]
 

--- a/modules/kubernetes-addons/external-dns/values.yaml
+++ b/modules/kubernetes-addons/external-dns/values.yaml
@@ -2,6 +2,3 @@ provider: aws
 zoneIdFilters: ${zone_filter_ids}
 aws:
   region: ${aws_region}
-serviceAccount:
-    create: false
-    name: ${service_account_name}

--- a/modules/kubernetes-addons/karpenter/locals.tf
+++ b/modules/kubernetes-addons/karpenter/locals.tf
@@ -10,18 +10,6 @@ locals {
     {
       name  = "serviceAccount.create"
       value = false
-    },
-    {
-      name  = "controller.clusterName"
-      value = var.addon_context.eks_cluster_id
-    },
-    {
-      name  = "controller.clusterEndpoint"
-      value = local.eks_cluster_endpoint
-    },
-    {
-      name  = "aws.defaultInstanceProfile"
-      value = var.node_iam_instance_profile
     }
   ]
 
@@ -53,7 +41,6 @@ locals {
   default_helm_values = [templatefile("${path.module}/values.yaml", {
     eks_cluster_id            = var.addon_context.eks_cluster_id,
     eks_cluster_endpoint      = local.eks_cluster_endpoint,
-    service_account_name      = local.service_account_name,
     node_iam_instance_profile = var.node_iam_instance_profile,
     operating_system          = "linux"
   })]
@@ -61,7 +48,6 @@ locals {
   argocd_gitops_config = {
     enable                    = true
     serviceAccountName        = local.service_account_name
-    controllerClusterName     = var.addon_context.eks_cluster_id
     controllerClusterEndpoint = local.eks_cluster_endpoint
     awsDefaultInstanceProfile = var.node_iam_instance_profile
   }

--- a/modules/kubernetes-addons/karpenter/values.yaml
+++ b/modules/kubernetes-addons/karpenter/values.yaml
@@ -1,6 +1,3 @@
-serviceAccount:
-  create: false
-  name: ${service_account_name}
 nodeSelector:
   kubernetes.io/os: ${operating_system}
 clusterName: ${eks_cluster_id}

--- a/modules/kubernetes-addons/keda/locals.tf
+++ b/modules/kubernetes-addons/keda/locals.tf
@@ -12,9 +12,7 @@ locals {
     timeout     = "1200"
   }
 
-  default_helm_values = [templatefile("${path.module}/values.yaml", {
-    sa-name = local.service_account_name
-  })]
+  default_helm_values = []
 
   helm_config = merge(
     local.default_helm_config,

--- a/modules/kubernetes-addons/keda/values.yaml
+++ b/modules/kubernetes-addons/keda/values.yaml
@@ -1,7 +1,3 @@
-serviceAccount:
-  create: false
-  name: ${sa-name}
-
 resources:
   limits:
     cpu: 1

--- a/modules/kubernetes-addons/kubernetes-dashboard/locals.tf
+++ b/modules/kubernetes-addons/kubernetes-dashboard/locals.tf
@@ -19,6 +19,8 @@ locals {
     var.helm_config
   )
 
+  default_helm_values = []
+
   set_values = [
     {
       name  = "serviceAccount.name"

--- a/modules/kubernetes-addons/kubernetes-dashboard/locals.tf
+++ b/modules/kubernetes-addons/kubernetes-dashboard/locals.tf
@@ -14,10 +14,6 @@ locals {
     timeout     = "1200"
   }
 
-  default_helm_values = [templatefile("${path.module}/values.yaml", {
-    sa-name = local.service_account_name
-  })]
-
   helm_config = merge(
     local.default_helm_config,
     var.helm_config

--- a/modules/kubernetes-addons/kubernetes-dashboard/values.yaml
+++ b/modules/kubernetes-addons/kubernetes-dashboard/values.yaml
@@ -1,3 +1,0 @@
-serviceAccount:
-  create: false
-  name: ${sa-name}

--- a/modules/kubernetes-addons/locals.tf
+++ b/modules/kubernetes-addons/locals.tf
@@ -17,7 +17,6 @@ locals {
     vpa                       = var.enable_vpa ? module.vpa[0].argocd_gitops_config : null
     yunikorn                  = var.enable_yunikorn ? module.yunikorn[0].argocd_gitops_config : null
     argoRollouts              = var.enable_argo_rollouts ? module.argo_rollouts[0].argocd_gitops_config : null
-    crossplane                = var.enable_crossplane ? module.crossplane[0].argocd_gitops_config : null
     karpenter                 = var.enable_karpenter ? module.karpenter[0].argocd_gitops_config : null
     kubernetesDashboard       = var.enable_kubernetes_dashboard ? module.kubernetes_dashboard[0].argocd_gitops_config : null
   }

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -112,15 +112,14 @@ module "cluster_autoscaler" {
 }
 
 module "crossplane" {
-  count             = var.enable_crossplane ? 1 : 0
-  source            = "./crossplane"
-  helm_config       = var.crossplane_helm_config
-  manage_via_gitops = var.argocd_manage_add_ons
-  aws_provider      = var.crossplane_aws_provider
-  jet_aws_provider  = var.crossplane_jet_aws_provider
-  account_id        = data.aws_caller_identity.current.account_id
-  aws_partition     = data.aws_partition.current.id
-  addon_context     = local.addon_context
+  count            = var.enable_crossplane ? 1 : 0
+  source           = "./crossplane"
+  helm_config      = var.crossplane_helm_config
+  aws_provider     = var.crossplane_aws_provider
+  jet_aws_provider = var.crossplane_jet_aws_provider
+  account_id       = data.aws_caller_identity.current.account_id
+  aws_partition    = data.aws_partition.current.id
+  addon_context    = local.addon_context
 }
 
 module "fargate_fluentbit" {

--- a/modules/kubernetes-addons/metrics-server/locals.tf
+++ b/modules/kubernetes-addons/metrics-server/locals.tf
@@ -6,7 +6,7 @@ locals {
     chart       = local.name
     repository  = "https://kubernetes-sigs.github.io/metrics-server/"
     version     = "3.8.1"
-    namespace   = local.name
+    namespace   = "kube-system"
     description = "Metric server helm Chart deployment configuration"
     values      = []
     timeout     = "1200"

--- a/modules/kubernetes-addons/metrics-server/main.tf
+++ b/modules/kubernetes-addons/metrics-server/main.tf
@@ -9,12 +9,10 @@ module "helm_addon" {
 }
 
 resource "kubernetes_namespace_v1" "this" {
-
   count = local.helm_config["namespace"] == "kube-system" ? 0 : 1
 
   metadata {
     name = local.helm_config["namespace"]
-
     labels = {
       "app.kubernetes.io/managed-by" = "terraform-eks-blueprints"
     }

--- a/modules/kubernetes-addons/metrics-server/main.tf
+++ b/modules/kubernetes-addons/metrics-server/main.tf
@@ -5,7 +5,7 @@ module "helm_addon" {
   irsa_config       = null
   addon_context     = var.addon_context
 
-  depends_on = [kubernetes_namespace_v1[0].this]
+  depends_on = [kubernetes_namespace_v1.this]
 }
 
 resource "kubernetes_namespace_v1" "this" {

--- a/modules/kubernetes-addons/metrics-server/main.tf
+++ b/modules/kubernetes-addons/metrics-server/main.tf
@@ -11,7 +11,7 @@ module "helm_addon" {
 resource "kubernetes_namespace_v1" "this" {
 
   count = local.helm_config["namespace"] == "kube-system" ? 0 : 1
-  
+
   metadata {
     name = local.helm_config["namespace"]
 

--- a/modules/kubernetes-addons/metrics-server/main.tf
+++ b/modules/kubernetes-addons/metrics-server/main.tf
@@ -5,10 +5,13 @@ module "helm_addon" {
   irsa_config       = null
   addon_context     = var.addon_context
 
-  depends_on = [kubernetes_namespace_v1.this]
+  depends_on = [kubernetes_namespace_v1[0].this]
 }
 
 resource "kubernetes_namespace_v1" "this" {
+
+  count = local.helm_config["namespace"] == "kube-system" ? 0 : 1
+  
   metadata {
     name = local.helm_config["namespace"]
 

--- a/modules/kubernetes-addons/traefik/README.md
+++ b/modules/kubernetes-addons/traefik/README.md
@@ -12,7 +12,9 @@ No requirements.
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | n/a |
 
 ## Modules
 
@@ -22,7 +24,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [kubernetes_namespace_v1.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
 
 ## Inputs
 

--- a/modules/kubernetes-addons/traefik/locals.tf
+++ b/modules/kubernetes-addons/traefik/locals.tf
@@ -1,6 +1,5 @@
 locals {
-  name                 = "traefik"
-  service_account_name = "traefik-sa"
+  name = "traefik"
 
   default_helm_config = {
     name        = local.name
@@ -8,29 +7,19 @@ locals {
     repository  = "https://helm.traefik.io/traefik"
     version     = "10.14.1"
     namespace   = local.name
-    description = "The Traefik HelmChart is focused on Traefik deployment configuration"
+    description = "The Traefik Helm Chart is focused on Traefik deployment configuration"
     values      = local.default_helm_values
     timeout     = "1200"
   }
 
-  default_helm_values = [templatefile("${path.module}/values.yaml", {
-    sa-name = local.service_account_name
-  })]
+  default_helm_values = []
 
   helm_config = merge(
     local.default_helm_config,
     var.helm_config
   )
 
-  irsa_config = {
-    kubernetes_namespace              = local.helm_config["namespace"]
-    kubernetes_service_account        = local.service_account_name
-    create_kubernetes_namespace       = true
-    create_kubernetes_service_account = true
-  }
-
   argocd_gitops_config = {
-    enable             = true
-    serviceAccountName = local.service_account_name
+    enable = true
   }
 }

--- a/modules/kubernetes-addons/traefik/main.tf
+++ b/modules/kubernetes-addons/traefik/main.tf
@@ -2,6 +2,18 @@ module "helm_addon" {
   source            = "../helm-addon"
   manage_via_gitops = var.manage_via_gitops
   helm_config       = local.helm_config
-  irsa_config       = local.irsa_config
+  irsa_config       = null
   addon_context     = var.addon_context
+
+  depends_on = [kubernetes_namespace_v1.this]
+}
+
+resource "kubernetes_namespace_v1" "this" {
+  metadata {
+    name = local.helm_config["namespace"]
+
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform-eks-blueprints"
+    }
+  }
 }

--- a/modules/kubernetes-addons/traefik/values.yaml
+++ b/modules/kubernetes-addons/traefik/values.yaml
@@ -1,2 +1,0 @@
-serviceAccount:
-  name: ${sa-name}

--- a/modules/kubernetes-addons/vpa/locals.tf
+++ b/modules/kubernetes-addons/vpa/locals.tf
@@ -1,6 +1,5 @@
 locals {
-  name                 = "vpa"
-  service_account_name = "vpa"
+  name = "vpa"
 
   default_helm_config = {
     name        = local.name
@@ -13,24 +12,14 @@ locals {
     timeout     = "1200"
   }
 
-  default_helm_values = [templatefile("${path.module}/values.yaml", {
-    sa-name = local.service_account_name
-  })]
+  default_helm_values = [templatefile("${path.module}/values.yaml", {})]
 
   helm_config = merge(
     local.default_helm_config,
     var.helm_config
   )
 
-  set_values = [
-    {
-      name  = "serviceAccount.name"
-      value = local.service_account_name
-    }
-  ]
-
   argocd_gitops_config = {
-    enable             = true
-    serviceAccountName = local.service_account_name
+    enable = true
   }
 }

--- a/modules/kubernetes-addons/vpa/main.tf
+++ b/modules/kubernetes-addons/vpa/main.tf
@@ -2,7 +2,6 @@ module "helm_addon" {
   source            = "../helm-addon"
   manage_via_gitops = var.manage_via_gitops
   helm_config       = local.helm_config
-  set_values        = local.set_values
   irsa_config       = null
   addon_context     = var.addon_context
 

--- a/modules/kubernetes-addons/vpa/values.yaml
+++ b/modules/kubernetes-addons/vpa/values.yaml
@@ -1,7 +1,4 @@
 # Default values for vertical-pod-autoscaler.
-serviceAccount:
-  name: ${sa-name}
-
 recommender:
   image:
     repository: k8s.gcr.io/autoscaling/vpa-recommender

--- a/modules/kubernetes-addons/yunikorn/README.md
+++ b/modules/kubernetes-addons/yunikorn/README.md
@@ -15,7 +15,9 @@ No requirements.
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | n/a |
 
 ## Modules
 
@@ -25,7 +27,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [kubernetes_namespace_v1.yunikorn](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
 
 ## Inputs
 

--- a/modules/kubernetes-addons/yunikorn/locals.tf
+++ b/modules/kubernetes-addons/yunikorn/locals.tf
@@ -1,6 +1,5 @@
 locals {
-  name                 = "yunikorn"
-  service_account_name = "yunikorn-admin"
+  name = "yunikorn"
   default_helm_config = {
     name        = local.name
     chart       = local.name
@@ -12,26 +11,14 @@ locals {
     timeout     = "1200"
   }
 
-  default_helm_values = [templatefile("${path.module}/values.yaml", {
-    sa-name = local.service_account_name
-  })]
+  default_helm_values = [templatefile("${path.module}/values.yaml", {})]
 
   helm_config = merge(
     local.default_helm_config,
     var.helm_config
   )
 
-  irsa_config = {
-    kubernetes_namespace              = local.helm_config["namespace"]
-    kubernetes_service_account        = local.service_account_name
-    create_kubernetes_namespace       = true
-    create_kubernetes_service_account = true
-    irsa_iam_policies                 = var.irsa_policies
-  }
-
   argocd_gitops_config = {
-    enable                   = true
-    serviceAccountName       = local.service_account_name
-    embedAdmissionController = false
+    enable = true
   }
 }

--- a/modules/kubernetes-addons/yunikorn/main.tf
+++ b/modules/kubernetes-addons/yunikorn/main.tf
@@ -2,6 +2,18 @@ module "helm_addon" {
   source            = "../helm-addon"
   manage_via_gitops = var.manage_via_gitops
   helm_config       = local.helm_config
-  irsa_config       = local.irsa_config
+  irsa_config       = null
   addon_context     = var.addon_context
+
+  depends_on = [kubernetes_namespace_v1.yunikorn]
+}
+
+resource "kubernetes_namespace_v1" "yunikorn" {
+  metadata {
+    name = local.helm_config["namespace"]
+
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform-eks-blueprints"
+    }
+  }
 }

--- a/modules/kubernetes-addons/yunikorn/values.yaml
+++ b/modules/kubernetes-addons/yunikorn/values.yaml
@@ -1,6 +1,3 @@
-global:
-  serviceAccount: ${sa-name}
-
 operatorPlugins: general,spark-k8s-operator
 
 service:


### PR DESCRIPTION
### What does this PR do?

1. Reconcile the mismatch between gitops and helm provider configurations. 
2. Clean up addons values.yaml to remove `serviceAccount` because we set the via set_values anyway. 
3. Remove gitops configuration from crossplane because there is no corresponding gitops config in the addons repo


### Motivation

Fix argocd example


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [x] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
